### PR TITLE
Handle each sighting independently

### DIFF
--- a/birdbuddy/queries/birds.py
+++ b/birdbuddy/queries/birds.py
@@ -326,3 +326,144 @@ fragment SightingRecognizedMysteryVisitorFields on SightingRecognizedMysteryVisi
   __typename
 }
 """
+
+SIGHTING_CHOOSE_MYSTERY = """
+mutation sightingConvertToMysteryVisitor($sightingConvertToMysteryVisitorInput: SightingConvertToMysteryVisitorInput!) {
+  sightingConvertToMysteryVisitor(
+    sightingConvertToMysteryVisitorInput: $sightingConvertToMysteryVisitorInput
+  ) {
+    ...SightingsReportFields
+    __typename
+  }
+}
+fragment SightingsReportFields on SightingReport {
+  reportToken
+  sightings {
+    ... on SightingCantDecideWhichBird {
+      ...SightingCantDecideWhichBirdFields
+      __typename
+    }
+    ... on SightingNoBird {
+      ...SightingFields
+      __typename
+    }
+    ... on SightingNoBirdRecognized {
+      ...SightingFields
+      __typename
+    }
+    ... on SightingRecognizedBird {
+      ...SightingRecognizedBirdFields
+      __typename
+    }
+    ... on SightingRecognizedBirdUnlocked {
+      ...SightingRecognizedBirdUnlockedFields
+      __typename
+    }
+    ... on SightingRecognizedMysteryVisitor {
+      ...SightingRecognizedMysteryVisitorFields
+      __typename
+    }
+    __typename
+  }
+  __typename
+}
+fragment SightingCantDecideWhichBirdFields on SightingCantDecideWhichBird {
+  ...SightingFields
+  suggestions {
+    ...CollectionSpeciesFields
+    __typename
+  }
+  __typename
+}
+fragment SightingFields on Sighting {
+  id
+  matchTokens
+  __typename
+}
+fragment CollectionSpeciesFields on CollectionSpecies {
+  isCollected
+  media {
+    ...MediaThumbnailFields
+    __typename
+  }
+  species {
+    ...SpeciesSingleFields
+    __typename
+  }
+  __typename
+}
+fragment MediaThumbnailFields on Media {
+  id
+  createdAt
+  thumbnailUrl
+  __typename
+}
+fragment SpeciesSingleFields on Species {
+  id
+  description
+  name
+  iconUrl
+  __typename
+}
+fragment SightingRecognizedBirdFields on SightingRecognizedBird {
+  ...SightingRecognizedFields
+  count
+  icon
+  shareableMatchTokens
+  species {
+    ...SpeciesAnyListFields
+    __typename
+  }
+  __typename
+}
+fragment SightingRecognizedFields on SightingRecognized {
+  ...SightingFields
+  color
+  text
+  __typename
+}
+fragment SpeciesAnyListFields on AnySpecies {
+  ... on SpeciesBird {
+    ...SpeciesListFields
+    isUnofficialName
+    mapUrl
+    __typename
+  }
+  ... on SpeciesBirdFamily {
+    ...SpeciesListFields
+    __typename
+  }
+  ... on SpeciesBirdGenus {
+    ...SpeciesListFields
+    __typename
+  }
+  ... on SpeciesBirdOrder {
+    ...SpeciesListFields
+    __typename
+  }
+  __typename
+}
+fragment SpeciesListFields on Species {
+  id
+  iconUrl
+  name
+  __typename
+}
+fragment SightingRecognizedBirdUnlockedFields on SightingRecognizedBirdUnlocked {
+  ...SightingFields
+  ...SightingRecognizedFields
+  shareableMatchTokens
+  species {
+    ...SpeciesAnyListFields
+    __typename
+  }
+  __typename
+}
+fragment SightingRecognizedMysteryVisitorFields on SightingRecognizedMysteryVisitor {
+  ...SightingFields
+  color
+  count
+  text
+  __typename
+}
+"""


### PR DESCRIPTION
A single SightingReport may contain multiple sightings: some of which can be finished as-is, some may need a manual species selection, and some may need to be collected as a mystery visitor.

Depending on the chosen postcard finishing strategy, we can handle each sighting separately - i.e., taking the recognized sightings and choosing the highest-confidence match if possible, but discarding unrecognized species.