### PR TITLE
Add support for videoMedia

### DIFF
--- a/birdbuddy/birds.py
+++ b/birdbuddy/birds.py
@@ -291,8 +291,13 @@ class PostcardSighting(UserDict[str, any]):
 
     @property
     def medias(self) -> list[Media]:
-        """List of medias for the sighting"""
+        """List of media for the sighting"""
         return [Media(m) for m in self.get("medias", [])]
+
+    @property
+    def video_media(self) -> list[Media]:
+        """List of Video media for the sighting"""
+        return [Media(v) for v in (self.get("videoMedia")) if v]
 
     @property
     def report(self) -> SightingReport:

--- a/birdbuddy/media.py
+++ b/birdbuddy/media.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import time
 from urllib.parse import urlparse, parse_qs
 
-from birdbuddy.feed import FeedNode
+from .feed import FeedNode
 
 
 class Media(UserDict):

--- a/birdbuddy/queries/birds.py
+++ b/birdbuddy/queries/birds.py
@@ -22,6 +22,10 @@ fragment SightingCreateFromPostcardFields on SightingCreateFromPostcardResult {
     ...SightingsReportFields
     __typename
   }
+  videoMedia {
+    ...MediaFullFields
+    __typename
+  }
   __typename
 }
 fragment FeederFields on Feeder {


### PR DESCRIPTION
This adds the `videoMedia` field on the `sightingCreateFromPostcard` response.

It is unclear yet if this will also enable saving the video with the other postcard media. Further testing is needed. It should at least return the video data, but saving media happens with `sightingReportPostcardFinish`, which just passes through the encoded `reportToken`. This change doesn't modify the token, but the hope is maybe requesting the videoMedia field will cause the returned reportToken to include what's necessary to save the video. If not, we still need to determine how to save the video to the collection.

There are other mutations/queries that take a mediaId, for example we can share media by id, or create a sighting from a matchToken (which seems to match mediaId). Unfortunately my feeder does not get visitors (maybe one in the past month), so I haven't been able to test this effectively.

Relates to #43.