### PR TITLE
Add language support

### DIFF
--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 
+import langcodes
 from python_graphql_client import GraphqlClient
 
 from . import LOGGER, VERBOSE, queries
@@ -45,6 +46,7 @@ class BirdBuddy:
     _password: str | None
     _access_token: str | None
     _refresh_token: str | None
+    _language_code: str
     _me: BirdBuddyUser | None
     _feeders: dict[str, Feeder]
     _collections: dict[str, Collection]
@@ -68,6 +70,7 @@ class BirdBuddy:
         self._last_feed_date = None
         self._feeders = {}
         self._collections = {}
+        self.language_code = "en"
 
     def _save_me(self, me_data: dict):
         if not me_data:
@@ -90,7 +93,10 @@ class BirdBuddy:
         return self._access_token is None
 
     def _headers(self) -> dict:
-        return {"Authorization": f"Bearer {self._access_token}"}
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Accept-Language": self._language_code,
+        }
 
     def _clear(self):
         self._access_token = None
@@ -216,6 +222,20 @@ class BirdBuddy:
     def user(self) -> None | BirdBuddyUser:
         """The logged in user data"""
         return self._me
+
+    @property
+    def language_code(self) -> str:
+        """The current language code"""
+        return self._language_code
+
+    @language_code.setter
+    def language_code(self, language_code: str):
+        """Override the language used in API requests.
+
+        This is useful to get localized responses, including translated
+        bird species names.
+        """
+        self._language_code = langcodes.standardize_tag(language_code)
 
     async def refresh(self) -> bool:
         """Refreshes the Bird Buddy feeder data"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-graphql-client==0.4.3
+langcodes

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ from setuptools import setup
 
 this_directory = path.abspath(path.dirname(__file__))
 
-with open(path.join(this_directory, "README.md"), "r", encoding='utf-8') as fh:
+with open(path.join(this_directory, "README.md"), "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name='pybirdbuddy',
-    version='0.0.14',
+    name="pybirdbuddy",
+    version="0.0.14",
     author="jhansche",
     author_email="madcoder@gmail.com",
     description="A library to query data about a Bird Buddy smart bird feeder",
@@ -20,5 +20,6 @@ setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "python-graphql-client",
+        "langcodes",
     ],
 )


### PR DESCRIPTION
This adds support for setting a language code that will be used for GraphQL requests. This will result in some strings being translated in the API responses, including bird species names for example.

This closes #13 