### PR TITLE
Add FeedItemCollectedPostcard

### DIFF
--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -12,6 +12,7 @@ from . import LOGGER
 class FeedNodeType(Enum):
     """Known Feed node types"""
 
+    CollectedPostcard = "FeedItemCollectedPostcard"
     GlobalImportant = "FeedGlobalImportantItem"
     GlobalRegular = "FeedGlobalRegularItem"
     InvitationConfirmed = "FeedItemFeederInvitationConfirmed"

--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -102,7 +102,11 @@ class Feed(UserDict[str, any]):
     @cached_property
     def newest_edge(self) -> FeedEdge | None:
         """Returns the newest `FeedEdge`, by `FeedNode.created_at`"""
-        return max(self.edges, key=lambda edge: edge.node.created_at, default=None)
+        return max(
+            (e for e in self.edges if e.node.created_at),
+            key=lambda edge: edge.node.created_at,
+            default=None
+        )
 
     def filter(
         self,

--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -44,6 +44,8 @@ class FeedNode(UserDict[str, any]):
     @staticmethod
     def parse_datetime(timestr: str) -> datetime:
         """Convert a time string into `datetime`."""
+        if timestr is None:
+            return None
         if len(timestr) == 24:
             # The known expected datetime format in the BirdBuddy feed
             return datetime.strptime(timestr, FeedNode._DATETIME_FORMAT)

--- a/birdbuddy/queries/me.py
+++ b/birdbuddy/queries/me.py
@@ -169,8 +169,27 @@ fragment AnyFeedItemFields on AnyFeedItem {
     ...MysteryVisitorResolvedFields
     __typename
   }
+  ... on FeedItemCollectedPostcard {
+    ...CollectedPostcardFields
+    __typename
+  }
   ... on FeedItemNewPostcard {
     ...NewPostcardFields
+    __typename
+  }
+  __typename
+}
+fragment CollectedPostcardFields on FeedItemCollectedPostcard {
+  ...FeedItemFields
+  expiresAt
+  hasNewSpecies
+  hasMysteryVisitor
+  medias {
+    ...MediaFullFields
+    __typename
+  }
+  species {
+    ...SpeciesAnyListFields
     __typename
   }
   __typename


### PR DESCRIPTION
A new feed item type was introduced, and since we didn't know about the schema, the `feed()` response was extremely sparse for those items - basically included only the cursor and type. We then try to sort by `createdAt` in order to select the newest edge in the feed, but because we weren't selecting the `createdAt` field in the GraphQL query, the field is `None`, which cannot be converted to a `datetime` and cannot take part in `max(key=lambda)`.

This change adds the new feed item type and related fields, and also attempts to fix the missing `createdAt` issue, so that new feed item types will not break the coordinator like this in the future.

This resolves https://github.com/jhansche/ha-birdbuddy/issues/73