### PR TITLE
Pin langcodes dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-graphql-client==0.4.3
-langcodes
+langcodes==3.3.0


### PR DESCRIPTION
langcodes 3.4.0, specifically language_data 1.2.0 adds a dependency on marisa-trie 1.1.0 doesn't seem to work in HA. This pins to 3.3.0 to resolve compatibility.