### PR TITLE
Add support for API interactions used to start and maintain a camera live stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,13 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS junk
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+.VolumeIcon.icns
+.fseventsd

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -246,6 +246,77 @@ class BirdBuddy:
         LOGGER.debug("Feeder data refreshed successfully: %s", data)
         return self._save_me(data["me"])
 
+    async def watching_start(self, feeder: Feeder) -> dict:
+        if isinstance(feeder, Feeder):
+            feeder_id = feeder.id
+            if not feeder.is_owner:
+                LOGGER.warning("Watching is only available to owner accounts (technically to premium accounts too but not supporting that now.)")
+        else:
+            feeder_id = feeder
+
+        variables = {
+            "feederId": feeder_id,
+            "startWatchingInput": {
+                "feederId": feeder_id,
+            },
+        }
+
+        result = await self._make_request(
+            query=queries.feeder.WATCHING_START,
+            variables=variables,
+            subscript="watchingStartV2"
+        )
+
+        LOGGER.debug(result)
+
+        while (result["__typename"] == "WatchingStartInProgressResult"):
+            await asyncio.sleep(5)
+
+            result = await self._make_request(
+                query=queries.feeder.WATCHING_START_CHECK,
+                variables=variables,
+                subscript="watchingStartCheck"
+            )
+
+            LOGGER.debug(result)
+
+        return result
+    
+    async def watching_start_check(self, feeder: Feeder) -> dict:
+        if isinstance(feeder, Feeder):
+            feeder_id = feeder.id
+            if not feeder.is_owner:
+                LOGGER.warning("Watching is only available to owner accounts (technically to premium accounts too but not supporting that now.)")
+        else:
+            feeder_id = feeder
+
+        variables = {
+            "feederId": feeder_id,
+            "startWatchingInput": {
+                "feederId": feeder_id,
+            },
+        }
+
+        result = await self._make_request(
+            query=queries.feeder.WATCHING_START_CHECK,
+            variables=variables,
+            subscript="watchingStartCheck"
+        )
+
+        LOGGER.debug(result)
+
+        return result
+
+    async def watching_active_keep(self) -> dict:
+        result = await self._make_request(
+            query=queries.feeder.WATCHING_ACTIVE_KEEP,
+            subscript="watchingActiveKeep"
+        )
+
+        LOGGER.debug(result)
+
+        return result
+
     async def toggle_off_grid(
         self,
         feeder: Feeder | str,

--- a/birdbuddy/queries/feeder.py
+++ b/birdbuddy/queries/feeder.py
@@ -1,5 +1,96 @@
 """Feeder queries"""
 
+WATCHING_START = """
+mutation watchingStartV2($startWatchingInput: StartWatchingInput!) {
+  watchingStartV2(startWatchingInput: $startWatchingInput) {
+    ... on WatchingActiveResult {
+      __typename
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+    ... on WatchingFailedResult {
+      __typename
+      failedReason
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+    ... on WatchingStartInProgressResult {
+      __typename
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+  }
+}
+"""
+
+WATCHING_START_CHECK = """
+mutation watchingStartCheck($startWatchingInput: StartWatchingInput!) {
+  watchingStartCheck(startWatchingInput: $startWatchingInput) {
+    ... on WatchingActiveResult {
+      __typename
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+    ... on WatchingFailedResult {
+      __typename
+      failedReason
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+    ... on WatchingStartInProgressResult {
+      __typename
+      watching {
+        createdByDifferentSession
+        id
+        imageUrls
+        state
+        streamUrl
+      }
+    }
+  }
+}
+"""
+
+WATCHING_ACTIVE_KEEP = """
+mutation watchingActiveKeep {
+  watchingActiveKeep {
+    ... on Watching {
+      __typename
+      createdByDifferentSession
+      id
+      imageUrls
+      state
+      streamUrl
+    }
+  }
+}
+"""
+
 TOGGLE_OFF_GRID = """
 mutation feederToggleOffGrid($feederId: ID!, $feederToggleOffGridInput: FeederToggleOffGridInput!) {
   feederToggleOffGrid(


### PR DESCRIPTION
Introduces the methods mapping to the API interactions for initiating a stream, checking on the stream initiation status, and maintaining the stream in an active state.

Here is a use case in action https://github.com/DavidValeri/bb-streamer. The output can be fed to an NVR or another identification system.