### PR TITLE
Paginate collection() to return all media

### DIFF
--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -828,23 +828,40 @@ class BirdBuddy:
                 del self._collections[collection.collection_id]
         return self._collections
 
-    async def collection(self, collection_id: str) -> dict[str, Media]:
-        """Return the media in the specified collection.
+    async def collection(
+        self, collection_id: str, page_size: int = 50
+    ) -> dict[str, Media]:
+        """Return all media in the specified collection.
 
-        The keys will be the ``media_id``, and values
+        The keys will be the ``media_id``, and the values are ``Media`` objects.
+        This method follows pagination so that collections with more than one
+        page of media are fully retrieved.
         """
-        variables = {
-            "collectionId": collection_id,
-            # other inputs: first, orderBy, last, after, before
-        }
-        data = await self._make_request(
-            query=queries.me.COLLECTIONS_MEDIA, variables=variables
-        )
-        # TODO: check [collection][media][pageInfo][hasNextPage]?
-        return {
-            (node := edge["node"]["media"])["id"]: Media(node)
-            for edge in data["collection"]["media"]["edges"]
-        }
+        result: dict[str, Media] = {}
+        after: str | None = None
+
+        while True:
+            variables = {
+                "collectionId": collection_id,
+                "first": page_size,
+                "after": after,
+            }
+            data = await self._make_request(
+                query=queries.me.COLLECTIONS_MEDIA, variables=variables
+            )
+            media = data["collection"]["media"]
+
+            for edge in media["edges"]:
+                node = edge["node"]["media"]
+                result[node["id"]] = Media(node)
+
+            page_info = media.get("pageInfo", {})
+            if page_info.get("hasNextPage"):
+                after = page_info["endCursor"]
+            else:
+                break
+
+        return result
 
     async def latest_collections(
         self,


### PR DESCRIPTION
## Problem

`collection()` only fetched the first page of results and discards the
rest, silently truncating larger collections. On my collection with 70
media items, the method returns only 40 — there's no error, so callers
have no indication data is missing.

This PR addresses the existing `# TODO: check [collection][media][pageInfo][hasNextPage]?`
in the method.

## Amplification

As above, I realized my my Python code was failing to retrieve the whole BB collection (all 157 media items dvivided into two "sub" collectons of 70 media items in one species and 87 media items in another species).   I was doing a lot of back and forth with Claude on code fixes where I used a helper function to make my code work.  However, I got around to thinking maybe I should actually fix the pybirdbuddy library, so I got Claude to suggest code.  So I'll be honest, it's more Claude than me!  However, I feel satisfied the code fixes including this library fix performed completely as intended, and I indeed showed this via testing.  A sense check indicated the fix was along the right lines.

## Fix

Follow the `pageInfo.endCursor` cursor (which the `COLLECTIONS_MEDIA`
query already requests) until `hasNextPage` is false, accumulating media
across all pages.

## Verification

Tested against a real collection of 70 media items:
- Before: `collection(id)` returned 40
- After: `collection(id)` returned all 70 - which is the correct number of media items in the speices collection I was testing for.

## Notes

- According to Claude the fix is backward compatible: same return type (`dict[str, Media]`); existing
  callers get the complete set instead of a truncated one.
- Adds an optional `page_size` parameter (default 50); no change to the
  GraphQL query was needed.