### PR TITLE
Adopt the ruff/pyright/pytest toolchain and gate CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,7 @@
-# Install the package with its dev extra and run the test suite.
+# Install dependencies, lint, type-check, test, and publish results across
+# Python versions.
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
 name: Python package
 
 on:
@@ -10,22 +13,43 @@ on:
 
 permissions:
   contents: read
+  checks: write # dorny/test-reporter publishes the JUnit results as a check run
+  pull-requests: write
 
 jobs:
   test:
-    name: pytest (py${{ matrix.python-version }})
+    name: make test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      # make test runs markdownlint (npx) and pyright, which both run on Node.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
       - name: Install dependencies
-        run: pip install ".[dev]"
-      - name: Run pytest
-        run: pytest
+        run: make deps
+      - name: Lint, type-check, and test
+        run: make test
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-py${{ matrix.python-version }}
+          path: |
+            junit.xml
+            htmlcov/
+      - name: Publish test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: Test Results (py${{ matrix.python-version }})
+          path: junit.xml
+          reporter: java-junit

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit.xml
 
 # Translations
 *.mo

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,17 @@
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint
+
+default: true
+
+# MD013 - Ignore line length in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
+
+# MD029 - Require ordered list numbering (1, 2, 3)
+MD029:
+  style: ordered
+
+# MD060 - Allow unaligned table pipes (long-cell content would force
+# excessive padding on every adjacent row)
+MD060: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+SHELL = /bin/bash
+
+# Create the venv with the interpreter pinned in .python-version and install
+# the dev/test/publish toolchain from the [dev] extra.
+.PHONY: deps
+.ONESHELL:
+deps:
+	set -e
+	@echo "Setting up the Python environment..."
+	python3 -m venv venv
+	. venv/bin/activate
+	pip install -U pip
+	pip install -e '.[dev]'
+	@echo "Dependencies installed."
+
+# Auto-fix formatting and lint issues.
+.PHONY: format
+.ONESHELL:
+format:
+	set -e
+	. venv/bin/activate
+	ruff format
+	ruff check --fix
+
+# Full gate: format check, lint, type check, and the entire test suite.
+.PHONY: test
+.ONESHELL:
+test:
+	@echo "Running format check, lint, type check, and tests..."
+	set -e
+	. venv/bin/activate
+	ruff check
+	ruff format --check --diff
+	npx -y markdownlint-cli2 "*.md"
+	pyright --venvpath . --warnings
+	python -m pytest
+	@echo "All checks passed."
+
+# Alias for `make test`.
+.PHONY: check
+check: test
+
+# Refresh the committed GraphQL schema fixture from the live API.
+.PHONY: schema
+.ONESHELL:
+schema:
+	set -e
+	. venv/bin/activate
+	python dump_schema.py
+
+# Build the sdist + wheel into dist/.
+.PHONY: build
+.ONESHELL:
+build:
+	set -e
+	. venv/bin/activate
+	rm -rf dist
+	python -m build
+
+# Build then upload to PyPI (requires credentials/token).
+.PHONY: publish
+.ONESHELL:
+publish: build
+	set -e
+	. venv/bin/activate
+	twine check dist/*
+	twine upload dist/*
+
+.PHONY: clean
+clean:
+	@echo "Cleaning up..."
+	rm -rf **/__pycache__
+	rm -rf .pytest_cache .ruff_cache htmlcov
+	rm -f .coverage .coverage.* junit.xml
+	rm -rf dist build *.egg-info
+	rm -rf venv
+	@echo "Cleanup complete."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # pybirdbuddy
 
+[![Build Status][build-status-shield]][build-status]
+![Maintenance][maintenance-shield]
+[![GitHub Release][releases-shield]][releases]
+[![PyPI Version][pypi-shield]][pypi]
+[![License][license-shield]](LICENSE)
+
+`pybirdbuddy` is an asynchronous Python client for the undocumented GraphQL
+API behind the Bird Buddy smart bird feeder. Sign in with a Bird Buddy account
+to read your feeders and their state, browse your collections and media, and
+finish the "postcard" sightings the feeder captures.
+
+It is an unofficial client for an undocumented API that can change without
+notice, and is not affiliated with or endorsed by Bird Buddy.
+
+## Installation
+
+```bash
+pip install pybirdbuddy
+```
+
+Python 3.10–3.14 is supported.
+
+## Usage
+
 ```python
 import asyncio
 import pprint
@@ -54,16 +78,63 @@ fragment ListFeederFields on FeederForPrivate {
 
 API responses can return translated strings by setting the client's
 `language_code` property. Language codes are parsed using
-[`langcodes`](https://pypi.org/project/langcodes/)
+[`langcodes`][langcodes].
 
 ```python
-from birdbuddy import BirdBuddy
+from birdbuddy.client import BirdBuddy
 
 async def main():
-    bb = BirdBuddy
+    bb = BirdBuddy("user@email.com", "Pa$$w0rd")
     bb.language_code = "de"
-    
+
     collections = await bb.refresh_collections()
     birds = [c.species.name for c in collections.values()]
     print(birds)
 ```
+
+## Development
+
+Install [pyenv] and the pinned interpreter, then use the Makefile — every
+target runs inside the project venv automatically:
+
+```bash
+pyenv install 3.10.20   # matches .python-version
+make deps               # create the venv and install the [dev] extra
+
+make test     # ruff + ruff format --check + markdownlint + pyright + pytest
+make check    # alias for `make test`
+make format   # auto-fix ruff issues and reformat
+make schema   # refresh schema.json from the live API
+```
+
+Alternatively, install the tooling into an existing environment with
+`pip install -e '.[dev]'`.
+
+## Releasing
+
+The package is published to [PyPI][pypi]. To cut a release:
+
+1. Bump `version` in `pyproject.toml` (if needed).
+2. `make build` — build the sdist and wheel into `dist/`.
+3. `make publish` — rebuild, run `twine check`, then upload to PyPI.
+
+`make publish` uses [Twine], which reads credentials from `~/.pypirc` or the
+`TWINE_USERNAME` / `TWINE_PASSWORD` environment variables; use `__token__` as
+the username and a PyPI API token (the value includes its `pypi-` prefix) as
+the password.
+
+## License
+
+Released under the [MIT No Attribution](LICENSE) license (MIT-0).
+
+[build-status]: https://github.com/jhansche/pybirdbuddy/actions/workflows/python-package.yml?query=branch%3Amain
+[build-status-shield]: https://img.shields.io/github/actions/workflow/status/jhansche/pybirdbuddy/python-package.yml?branch=main&style=for-the-badge
+[langcodes]: https://pypi.org/project/langcodes/
+[license-shield]: https://img.shields.io/github/license/jhansche/pybirdbuddy.svg?style=for-the-badge
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026?style=for-the-badge
+[pyenv]: https://github.com/pyenv/pyenv
+[pypi]: https://pypi.org/project/pybirdbuddy/
+[pypi-shield]: https://img.shields.io/pypi/v/pybirdbuddy?style=for-the-badge
+[releases]: https://github.com/jhansche/pybirdbuddy/releases
+[releases-shield]: https://img.shields.io/github/v/release/jhansche/pybirdbuddy.svg?style=for-the-badge
+[twine]: https://twine.readthedocs.io/

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ pprint.pprint(result)
 pprint.pprint(bb.feeders)
 ```
 
-Note: only password login is supported currently. Google and other SSOs are not supported. If
-you've already set up your Bird Buddy with SSO, one option could be to register a new account with
-a password, and then redeem an invite code to your Bird Buddy under the new account. Some fields
-will be missing (such as firmware versions and off-grid status).
+Note: only password login is supported currently. Google and other SSOs are
+not supported. If you've already set up your Bird Buddy with SSO, one option
+could be to register a new account with a password, and then redeem an invite
+code to your Bird Buddy under the new account. Some fields will be missing
+(such as firmware versions and off-grid status).
 
 The `feeders` property will be an array of feeders with the following fields:
 
@@ -51,8 +52,9 @@ fragment ListFeederFields on FeederForPrivate {
 
 ## Translations
 
-API responses can return translated strings by setting the client's `language_code` property.
-Language codes are parsed using [`langcodes`](https://pypi.org/project/langcodes/)
+API responses can return translated strings by setting the client's
+`language_code` property. Language codes are parsed using
+[`langcodes`](https://pypi.org/project/langcodes/)
 
 ```python
 from birdbuddy import BirdBuddy

--- a/birdbuddy/__init__.py
+++ b/birdbuddy/__init__.py
@@ -1,4 +1,4 @@
-"""Bird Buddy api library"""
+"""Bird Buddy api library."""
 
 import logging
 

--- a/birdbuddy/birds.py
+++ b/birdbuddy/birds.py
@@ -1,18 +1,19 @@
-"""Data models relating to bird Species"""
+"""Data models relating to bird Species."""
 
 from __future__ import annotations
+
 from collections import UserDict
 
 
 class Species(UserDict[str, str]):
-    """Species"""
+    """Species."""
 
     @property
     def id(self) -> str:
-        """Species id or code"""
+        """Species id or code."""
         return self["id"]
 
     @property
     def name(self) -> str:
-        """Species name"""
+        """Species name."""
         return self["name"]

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -513,6 +513,9 @@ class BirdBuddy:
                 msg = f"expected a NewPostcard, got {postcard.node_type}"
                 raise ValueError(msg)
             postcard_id = postcard.node_id
+        else:
+            msg = f"postcard must be a str or FeedNode, got {type(postcard)}"
+            raise TypeError(msg)
 
         variables = {"feedItemId": postcard_id}
         result = await self._make_request(
@@ -549,6 +552,9 @@ class BirdBuddy:
                 msg = f"expected a NewPostcard, got {postcard.node_type}"
                 raise ValueError(msg)
             postcard_id = postcard.node_id
+        else:
+            msg = f"postcard must be a str or FeedNode, got {type(postcard)}"
+            raise TypeError(msg)
         variables = {
             "sightingCreateFromPostcardInput": {
                 "feedItemId": postcard_id,

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -4,23 +4,25 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from typing import Any
 
 import langcodes
 from python_graphql_client import GraphqlClient
 
-from . import LOGGER, VERBOSE, queries
-from .const import BB_URL
-from .exceptions import (
+from birdbuddy import LOGGER, VERBOSE, queries
+from birdbuddy.const import BB_URL
+from birdbuddy.exceptions import (
     AuthenticationFailedError,
     AuthTokenExpiredError,
     GraphqlError,
     NoResponseError,
     UnexpectedResponseError,
 )
-from .feed import Feed, FeedNode, FeedNodeType
-from .feeder import Feeder, FeederUpdateStatus, PowerProfile
-from .media import Collection, Media
-from .sightings import (
+from birdbuddy.feed import Feed, FeedNode, FeedNodeType
+from birdbuddy.feeder import Feeder, FeederUpdateStatus, PowerProfile
+from birdbuddy.media import Collection, Media
+from birdbuddy.queries.debug import DUMP_SCHEMA
+from birdbuddy.sightings import (
     PostcardSighting,
     Sighting,
     SightingCreateProgress,
@@ -28,13 +30,13 @@ from .sightings import (
     SightingFinishStrategy,
     SightingReport,
 )
-from .user import BirdBuddyUser
+from birdbuddy.user import BirdBuddyUser
 
 _NO_VALUE = object()
 """Sentinel value to allow None to override a default value."""
 
 
-def _redact(data, redacted: bool = True):
+def _redact(data: object, redacted: bool = True) -> object:
     """Return a redacted string if necessary."""
     return "**REDACTED**" if redacted else data
 
@@ -51,7 +53,7 @@ class BirdBuddy:
     _me: BirdBuddyUser | None
     _feeders: dict[str, Feeder]
     _collections: dict[str, Collection]
-    _last_feed_date: datetime
+    _last_feed_date: datetime | None
 
     def __init__(
         self,
@@ -61,7 +63,14 @@ class BirdBuddy:
         refresh_token: str | None = None,
         access_token: str | None = None,
     ) -> None:
-        """Initialize the Bird Buddy client."""
+        """Initialize the Bird Buddy client.
+
+        Args:
+            email: Account email, for password login.
+            password: Account password, for password login.
+            refresh_token: An existing refresh token, to skip password login.
+            access_token: An existing access token.
+        """
         self._email = email
         self._password = password
         self._refresh_token = refresh_token
@@ -74,7 +83,7 @@ class BirdBuddy:
         self._collections = {}
         self.language_code = "en"
 
-    def _save_me(self, me_data: dict):
+    def _save_me(self, me_data: dict) -> bool:
         if not me_data:
             return False
         me_data["__last_updated"] = datetime.now()
@@ -100,16 +109,13 @@ class BirdBuddy:
             "Accept-Language": self._language_code,
         }
 
-    def _clear(self):
+    def _clear(self) -> None:
         self._access_token = None
         self._refresh_token = None
         self._me = None
 
     async def dump_schema(self) -> dict:
         """For debugging purposes: dump the entire GraphQL schema."""
-        # pylint: disable=import-outside-toplevel
-        from .queries.debug import DUMP_SCHEMA
-
         return await self._make_request(query=DUMP_SCHEMA, auth=False)
 
     async def _check_auth(self) -> bool:
@@ -122,7 +128,18 @@ class BirdBuddy:
         return not self._needs_login()
 
     async def _login(self) -> bool:
-        assert self._email and self._password
+        """Sign in with email/password and store the tokens.
+
+        Returns:
+            ``True`` if the user profile was saved.
+
+        Raises:
+            AuthenticationFailedError: If credentials are missing or the
+                sign-in request fails.
+        """
+        if not (self._email and self._password):
+            msg = "email and password are required to sign in"
+            raise AuthenticationFailedError(msg)
         variables = {
             "emailSignInInput": {
                 "email": self._email,
@@ -145,7 +162,18 @@ class BirdBuddy:
         return self._save_me(result["me"])
 
     async def _refresh_access_token(self) -> bool:
-        assert self._refresh_token
+        """Exchange the refresh token for a new access token.
+
+        Returns:
+            ``True`` once a new access token is set.
+
+        Raises:
+            AuthenticationFailedError: If no refresh token is set or the
+                refresh request fails.
+        """
+        if not self._refresh_token:
+            msg = "a refresh token is required to refresh the access token"
+            raise AuthenticationFailedError(msg)
         variables = {
             "refreshTokenInput": {
                 "token": self._refresh_token,
@@ -176,14 +204,33 @@ class BirdBuddy:
         reauth: bool = True,
         subscript: str | None = None,
     ) -> dict:
-        """Make the request, check for errors, and return the unwrapped data."""
+        """Execute a GraphQL request and return the unwrapped ``data``.
+
+        Args:
+            query: The GraphQL query or mutation string.
+            variables: GraphQL variables, if any.
+            auth: Whether to attach auth headers (refreshing tokens first).
+            reauth: Whether to retry once after an expired-token error.
+            subscript: If set, return ``data[subscript]`` instead of ``data``.
+
+        Returns:
+            The response ``data`` dict, or ``data[subscript]`` when given.
+
+        Raises:
+            NoResponseError: If the response was empty or not a dict.
+            UnexpectedResponseError: If the response carried no ``data``.
+            GraphqlError: If the response reported one or more errors.
+        """
         if auth:
             await self._check_auth()
             headers = self._headers()
         else:
             headers = {}
 
-        should_redact = query in [queries.auth.REFRESH_AUTH_TOKEN, queries.auth.SIGN_IN]
+        should_redact = query in [
+            queries.auth.REFRESH_AUTH_TOKEN,
+            queries.auth.SIGN_IN,
+        ]
         LOGGER.debug(
             "> GraphQL %s, vars=%s",
             query.partition("\n")[0],  # First line of query
@@ -191,7 +238,7 @@ class BirdBuddy:
         )
         response = await self.graphql.execute_async(
             query=query,
-            variables=variables,
+            variables=variables or {},
             headers=headers,
         )
 
@@ -233,11 +280,15 @@ class BirdBuddy:
         return self._language_code
 
     @language_code.setter
-    def language_code(self, language_code: str):
-        """Override the language used in API requests.
+    def language_code(self, language_code: str) -> None:
+        """Set the language used in API requests.
 
-        This is useful to get localized responses, including translated
-        bird species names.
+        Useful for localized responses, including translated bird species
+        names.
+
+        Args:
+            language_code: A BCP 47 language tag (e.g. ``"de"``), normalized
+                via ``langcodes.standardize_tag``.
         """
         self._language_code = langcodes.standardize_tag(language_code)
 
@@ -254,7 +305,14 @@ class BirdBuddy:
     ) -> Feeder:
         """Toggle the feeder's off-grid status.
 
-        Available to Owner account only.
+        Available to the owner account only.
+
+        Args:
+            feeder: The Feeder or its id to update.
+            is_off_grid: Whether to enable off-grid mode.
+
+        Returns:
+            The Feeder once the status has updated.
         """
         if isinstance(feeder, Feeder):
             feeder_id = feeder.id
@@ -282,7 +340,7 @@ class BirdBuddy:
         while new_off_grid != is_off_grid:
             LOGGER.debug("waiting for off-grid to update")
             await asyncio.sleep(1)
-            assert await self.refresh()
+            await self.refresh()
             new_off_grid = self.feeders[feeder_id].is_off_grid
         return self.feeders[feeder_id]
 
@@ -293,7 +351,14 @@ class BirdBuddy:
     ) -> Feeder:
         """Toggle the feeder's audio-enabled setting.
 
-        Available to Owner account only.
+        Available to the owner account only.
+
+        Args:
+            feeder: The Feeder or its id to update.
+            is_audio_enabled: Whether videos should include audio.
+
+        Returns:
+            The Feeder once the setting has updated.
         """
         if isinstance(feeder, Feeder):
             feeder_id = feeder.id
@@ -321,7 +386,7 @@ class BirdBuddy:
         while new_setting != is_audio_enabled:
             LOGGER.debug("waiting for audio setting to update")
             await asyncio.sleep(1)
-            assert await self.refresh()
+            await self.refresh()
             new_setting = self.feeders[feeder_id].is_audio_enabled
         return self.feeders[feeder_id]
 
@@ -329,21 +394,26 @@ class BirdBuddy:
         self,
         first: int = 20,
         after: str | None = None,
-        last: int | None = None,
+        last: int | None = None,  # noqa: ARG002
         before: str | None = None,
     ) -> Feed:
         """Return the Bird Buddy Feed.
 
-        The returned dictionary contains a `"pageInfo"` key for pagination/cursor data; and an
-        `"edges"` key containing a list of FeedEdge nodes, most recent items listed first.
+        The result contains a ``"pageInfo"`` key for pagination/cursor data
+        and an ``"edges"`` key with FeedEdge nodes, newest first.
 
-        :param first: Return the first N items older than `after`
-        :param after: The cursor of the oldest item previously seen, to allow pagination of very long feeds
-        :param last: Return the last N items newer than `before`
-        :param before: The cursor of the newest item previously seen, to allow pagination of very long feeds
-        :param newer_than: `datetime` or `str` of the most recent feed item previously seen
+        Args:
+            first: Return the first N items older than ``after``.
+            after: Cursor of the oldest item previously seen (pagination).
+            last: Return the last N items newer than ``before``. Currently
+                ignored; the backward-pagination request path is disabled.
+            before: Cursor of the newest item previously seen. Currently
+                ignored (see ``last``).
+
+        Returns:
+            The Feed.
         """
-        variables = {
+        variables: dict[str, Any] = {
             # $first: Int,
             # $after: String,
             # $last: Int,
@@ -356,7 +426,7 @@ class BirdBuddy:
             variables["after"] = after
 
         if before:
-            # Not implemented: birdbuddy.exceptions.GraphqlError: 501: 'Not Implemented'
+            # Not implemented server-side (GraphqlError 501).
             #  variables["before"] = before
             #  variables["last"] = last if last else 20
             pass
@@ -364,19 +434,26 @@ class BirdBuddy:
         data = await self._make_request(query=queries.me.FEED, variables=variables)
         return Feed(data["me"]["feed"])
 
-    async def refresh_feed(self, since: datetime | str = _NO_VALUE) -> list[FeedNode]:
-        """Get only fresh feed items, new since the last Feed refresh.
+    async def refresh_feed(
+        self,
+        since: datetime | str = _NO_VALUE,  # type: ignore[assignment]
+    ) -> list[FeedNode]:
+        """Return only feed items new since the last refresh.
 
-        The most recent edge node timestamp will be saved as the last seen feed item,
-        which will become the new default value for `since`. This can be useful to,
+        The most recent edge node timestamp is saved as the last-seen feed
+        item, which becomes the new default value for ``since``. Useful to,
         for example, restore a last-seen timestamp in a new instance.
 
-        :param since: The `datetime` after which to restrict new feed items.
+        Args:
+            since: The time after which to restrict new feed items; defaults
+                to the last-seen timestamp.
+
+        Returns:
+            The new feed nodes.
         """
-        if since == _NO_VALUE:
-            since = self._last_feed_date
-        if isinstance(since, str):
-            since = FeedNode.parse_datetime(since)
+        resolved = self._last_feed_date if since is _NO_VALUE else since
+        if isinstance(resolved, str):
+            resolved = FeedNode.parse_datetime(resolved)
         feed = await self.feed()
         if (newest_edge := feed.newest_edge) and (
             newest_date := newest_edge.node.created_at
@@ -387,17 +464,25 @@ class BirdBuddy:
                 newest_date,
             )
             self._last_feed_date = newest_date
-        return feed.filter(newer_than=since)
+        return feed.filter(newer_than=resolved)
 
-    async def feed_nodes(self, node_type: str) -> list[FeedNode]:
-        """Return all feed items of type ``node_type``."""
+    async def feed_nodes(self, node_type: FeedNodeType) -> list[FeedNode]:
+        """Return all feed items of the given type.
+
+        Args:
+            node_type: The feed node type to filter by.
+
+        Returns:
+            The matching feed nodes.
+        """
         feed = await self.feed()
         return feed.filter(of_type=node_type)
 
     async def new_postcards(self) -> list[FeedNode]:
         """Return all new 'Postcard' feed items.
 
-        These Postcard node types will be converted into sightings using ``sighting_from_postcard``.
+        These node types are converted into sightings using
+        ``sighting_from_postcard``.
         """
         return await self.feed_nodes(FeedNodeType.NewPostcard)
 
@@ -407,16 +492,28 @@ class BirdBuddy:
     ) -> dict:
         """Trigger the AI identification (reanalysis) for a postcard.
 
-        This changes the inference execution mode from MANUAL_NOT_STARTED to MANUAL_COMPLETED
-        and populates the sighting report preview.
+        Changes the inference execution mode from MANUAL_NOT_STARTED to
+        MANUAL_COMPLETED and populates the sighting report preview.
+
+        Args:
+            postcard: A postcard feed-item id, or a ``NewPostcard`` FeedNode.
+
+        Returns:
+            The ``inferenceExternalPostcardReanalyze`` result payload.
+
+        Raises:
+            ValueError: If ``postcard`` is a FeedNode that is not a
+                NewPostcard.
         """
         postcard_id: str
         if isinstance(postcard, str):
             postcard_id = postcard
         elif isinstance(postcard, FeedNode):
-            assert postcard.node_type == FeedNodeType.NewPostcard
+            if postcard.node_type != FeedNodeType.NewPostcard:
+                msg = f"expected a NewPostcard, got {postcard.node_type}"
+                raise ValueError(msg)
             postcard_id = postcard.node_id
-        
+
         variables = {"feedItemId": postcard_id}
         result = await self._make_request(
             query=queries.birds.POSTCARD_REANALYZE,
@@ -428,17 +525,29 @@ class BirdBuddy:
         self,
         postcard: str | FeedNode,
     ) -> PostcardSighting:
-        """Convert a 'postcard' into a 'sighting report'.
+        """Convert a postcard into a sighting report.
 
-        Next step is to choose or confirm species and then finish the sighting.
-        If the sighting type is ``SightingRecognized``, we can collect the sighting with
-        ``finish_postcard``.
+        Next step is to choose or confirm species and then finish the
+        sighting. If the sighting type is ``SightingRecognized``, it can be
+        collected with ``finish_postcard``.
+
+        Args:
+            postcard: A postcard feed-item id, or a ``NewPostcard`` FeedNode.
+
+        Returns:
+            The ``PostcardSighting`` for the postcard.
+
+        Raises:
+            ValueError: If ``postcard`` is a FeedNode that is not a
+                NewPostcard.
         """
         postcard_id: str
         if isinstance(postcard, str):
             postcard_id = postcard
         elif isinstance(postcard, FeedNode):
-            assert postcard.node_type == FeedNodeType.NewPostcard
+            if postcard.node_type != FeedNodeType.NewPostcard:
+                msg = f"expected a NewPostcard, got {postcard.node_type}"
+                raise ValueError(msg)
             postcard_id = postcard.node_id
         variables = {
             "sightingCreateFromPostcardInput": {
@@ -450,7 +559,7 @@ class BirdBuddy:
             variables=variables,
         )
         data = result["sightingCreateFromPostcard"]
-        return PostcardSighting(data).with_postcard(postcard)
+        return PostcardSighting(data).with_postcard(postcard_id)
 
     async def finish_postcard(
         self,
@@ -460,16 +569,20 @@ class BirdBuddy:
         confidence_threshold: int | None = None,
         share_media: bool = False,
     ) -> bool:
-        """Finish collecting the postcard in your collections.
+        """Finish collecting the postcard into your collections.
 
-        :param feed_item_id the id from ``new_postcards``
-        :param sighting_result from ``sighting_from_postcard``, should contain sightings of type
-        ``SightingRecognizedBird`` or `SightingRecognizedBirdUnlocked``.
-        :param strategy Finishing strategy, one of `RECOGNIZED`, `BEST_GUESS`, or `MYSTERY`
-        :param confidence_threshold Threshold for `BEST_GUESS` strategy to accept the highest
-        confidence suggestion above this threshold. Defaults to 10 (%).
-        :param share_media ``True`` to automatically share finished media to the community.
-        Defaults to ``False``.
+        Args:
+            feed_item_id: The id from ``new_postcards``.
+            sighting_result: From ``sighting_from_postcard``; should contain
+                sightings of type ``SightingRecognizedBird`` or
+                ``SightingRecognizedBirdUnlocked``.
+            strategy: One of ``RECOGNIZED``, ``BEST_GUESS``, or ``MYSTERY``.
+            confidence_threshold: For ``BEST_GUESS``, accept the highest
+                confidence suggestion above this threshold (defaults to 10%).
+            share_media: ``True`` to share the finished media.
+
+        Returns:
+            ``True`` if the postcard was finished successfully.
         """
         if not isinstance(sighting_result, PostcardSighting):
             # See sighting_from_postcard()["sightingCreateFromPostcard"]
@@ -478,8 +591,8 @@ class BirdBuddy:
 
         report = sighting_result.report
 
-        sighting: Sighting = None
-        mod: SightingFinishMod = None
+        sighting: Sighting | None = None
+        mod: SightingFinishMod | None = None
         for sighting, mod in report.sighting_finishing_strategies(
             confidence_threshold
         ).values():
@@ -498,14 +611,15 @@ class BirdBuddy:
                 )
             elif mod.strategy == SightingFinishStrategy.BEST_GUESS:
                 # Choose the highest recommended species
+                match_data = mod.data or {}
                 LOGGER.debug(
                     "selecting highest confidence: %s%% for species %s",
-                    mod.data["confidence"],
-                    mod.data["speciesCode"],
+                    match_data["confidence"],
+                    match_data["speciesCode"],
                 )
                 new_report = await self.sighting_choose_species(
                     sighting.id,
-                    mod.data["speciesCode"],
+                    match_data["speciesCode"],
                     report,
                 )
                 LOGGER.debug(
@@ -520,7 +634,7 @@ class BirdBuddy:
                     report,
                 )
                 LOGGER.debug(
-                    "replacing report after converting to mystery:\nold=%s\nnew=%s",
+                    "replacing report (mystery):\nold=%s\nnew=%s",
                     report,
                     new_report,
                 )
@@ -559,7 +673,15 @@ class BirdBuddy:
         return result
 
     async def share_medias(self, media_ids: list[str], share: bool = True) -> bool:
-        """Toggle media sharing."""
+        """Toggle sharing for the given media.
+
+        Args:
+            media_ids: The media ids to update.
+            share: ``True`` to share, ``False`` to unshare.
+
+        Returns:
+            ``True`` if the toggle succeeded.
+        """
         variables = {
             "mediaShareToggleInput": {
                 "mediaIds": media_ids,
@@ -576,7 +698,14 @@ class BirdBuddy:
         self,
         media_ids: list[str],
     ) -> SightingCreateProgress:
-        """Identify birds in media, starting a background identification process."""
+        """Identify birds in media via a background process.
+
+        Args:
+            media_ids: The media ids to analyze.
+
+        Returns:
+            The initial ``SightingCreateProgress``.
+        """
         variables = {
             "sightingCreateInput": {
                 "mediaIds": media_ids,
@@ -595,7 +724,16 @@ class BirdBuddy:
         sighting_create_id: str,
         watching_id: str,
     ) -> SightingCreateProgress | SightingReport:
-        """Check the progress of a background bird identification."""
+        """Check the progress of a background bird identification.
+
+        Args:
+            sighting_create_id: The id from ``sighting_create``.
+            watching_id: The watching id to poll.
+
+        Returns:
+            A ``SightingCreateProgress`` while pending, or a ``SightingReport``
+            once identification completes.
+        """
         variables = {
             "sightingCreateCheckProgressInput": {
                 "sightingCreateId": sighting_create_id,
@@ -615,18 +753,29 @@ class BirdBuddy:
         self,
         sighting_id: str,
         species_id: str,
-        sighting_data: SightingReport | str = None,
+        sighting_data: SightingReport | str | None = None,
     ) -> SightingReport:
-        """Manually assign a species to a sighting."""
-        token: str
+        """Manually assign a species to a sighting.
+
+        Args:
+            sighting_id: The sighting to update.
+            species_id: The species to assign.
+            sighting_data: The ``SightingReport`` or its report token.
+
+        Returns:
+            The updated ``SightingReport``.
+
+        Raises:
+            TypeError: If ``sighting_data`` is not a SightingReport or token.
+        """
+        token: str | None
         if isinstance(sighting_data, SightingReport):
             token = sighting_data.token
         elif isinstance(sighting_data, str):
             token = sighting_data
         else:
-            raise TypeError(
-                "sighting_data should be the `SightingReport` or `SightingReport.token`"
-            )
+            msg = "sighting_data should be a SightingReport or its token"
+            raise TypeError(msg)
         variables = {
             "sightingChooseSpeciesInput": {
                 "sightingId": sighting_id,
@@ -643,18 +792,28 @@ class BirdBuddy:
     async def sighting_choose_mystery(
         self,
         sighting_id: str,
-        sighting_data: SightingReport | str = None,
+        sighting_data: SightingReport | str | None = None,
     ) -> SightingReport:
-        """Convert the sighting into a mystery visitor."""
-        token: str
+        """Convert the sighting into a mystery visitor.
+
+        Args:
+            sighting_id: The sighting to convert.
+            sighting_data: The ``SightingReport`` or its report token.
+
+        Returns:
+            The updated ``SightingReport``.
+
+        Raises:
+            TypeError: If ``sighting_data`` is not a SightingReport or token.
+        """
+        token: str | None
         if isinstance(sighting_data, SightingReport):
             token = sighting_data.token
         elif isinstance(sighting_data, str):
             token = sighting_data
         else:
-            raise TypeError(
-                "sighting_data should be the `SightingReport` or `SightingReport.token`"
-            )
+            msg = "sighting_data should be a SightingReport or its token"
+            raise TypeError(msg)
         variables = {
             "sightingConvertToMysteryVisitorInput": {
                 "sightingId": sighting_id,
@@ -668,7 +827,14 @@ class BirdBuddy:
         return SightingReport(data["sightingConvertToMysteryVisitor"])
 
     async def refresh_collections(self, of_type: str = "bird") -> dict[str, Collection]:
-        """Return the remote bird collections."""
+        """Fetch and cache the remote collections.
+
+        Args:
+            of_type: The collection type to keep (e.g. ``"bird"``).
+
+        Returns:
+            The cached collections, keyed by collection id.
+        """
         data = await self._make_request(query=queries.me.COLLECTIONS)
         collections = {
             (c := Collection(d)).collection_id: c
@@ -679,22 +845,25 @@ class BirdBuddy:
         self._collections.update(collections)
         return self._collections
 
-    async def set_feeder_options(self, feeder: Feeder | str, **kwargs) -> dict:
+    async def set_feeder_options(
+        self, feeder: Feeder | str, **kwargs: bool | str
+    ) -> dict:
         """Update Feeder options.
 
-        Options can be specified as `kwargs`:
-        * `lowBatteryNotification: bool`
-        * `lowFoodNotification: bool`
-        * `name: str`
-        * `offGrid: bool`
-        * `offlineMode: bool`
+        Args:
+            feeder: The Feeder or its id to update.
+            **kwargs: Feeder options to set. Recognized keys:
+                ``lowBatteryNotification`` (bool), ``lowFoodNotification``
+                (bool), ``name`` (str), ``offGrid`` (bool), ``offlineMode``
+                (bool).
+
+        Returns:
+            The updated feeder-options payload.
         """
         if isinstance(feeder, Feeder):
             feeder_id = feeder.id
             if not feeder.is_owner:
-                LOGGER.warning(
-                    "Setting Feeder options is available only to owner accounts"
-                )
+                LOGGER.warning("Setting Feeder options requires an owner account")
         else:
             feeder_id = feeder
         variables = {
@@ -723,7 +892,15 @@ class BirdBuddy:
     async def set_power_profile(
         self, feeder: Feeder | str, profile: PowerProfile
     ) -> dict:
-        """Update the power profile."""
+        """Update the feeder's power profile.
+
+        Args:
+            feeder: The Feeder or its id to update.
+            profile: The power profile to set.
+
+        Returns:
+            A dict with the resulting ``powerProfile``.
+        """
         if isinstance(feeder, Feeder):
             feeder_id = feeder.id
             if not feeder.is_owner:
@@ -741,7 +918,7 @@ class BirdBuddy:
             variables=variables,
             subscript="feederUpdatePowerProfile",
         )
-        # This may raise GraphqlError code `PAYMENTS_SUBSCRIPTION_IS_NOT_ACTIVE`,
+        # May raise GraphqlError `PAYMENTS_SUBSCRIPTION_IS_NOT_ACTIVE`,
         # implying that `FRENZY_MODE` is a paid feature.
         updated = {"powerProfile": result.get("feeder", {}).get("powerProfile", None)}
 
@@ -757,7 +934,14 @@ class BirdBuddy:
         return updated
 
     async def update_firmware_start(self, feeder: Feeder | str) -> FeederUpdateStatus:
-        """Start a firmware update."""
+        """Start a firmware update.
+
+        Args:
+            feeder: The Feeder or its id to update.
+
+        Returns:
+            The firmware update status.
+        """
         current_status = await self.update_firmware_check(feeder)
 
         if current_status.is_in_progress:
@@ -790,8 +974,15 @@ class BirdBuddy:
             self.feeders[feeder_id].update(result.get("feeder", {}))
         return result
 
-    async def update_firmware_check(self, feeder: Feeder | str):
-        """Check on a firmware update."""
+    async def update_firmware_check(self, feeder: Feeder | str) -> FeederUpdateStatus:
+        """Check on a firmware update.
+
+        Args:
+            feeder: The Feeder or its id to check.
+
+        Returns:
+            The current firmware update status.
+        """
         if isinstance(feeder, Feeder):
             if not feeder.is_owner:
                 LOGGER.warning("Firmware update is available only to owner accounts")
@@ -831,7 +1022,11 @@ class BirdBuddy:
     async def collection(self, collection_id: str) -> dict[str, Media]:
         """Return the media in the specified collection.
 
-        The keys will be the ``media_id``, and values
+        Args:
+            collection_id: The collection ``UUID``.
+
+        Returns:
+            A mapping of ``media_id`` to its ``Media``.
         """
         variables = {
             "collectionId": collection_id,
@@ -850,7 +1045,8 @@ class BirdBuddy:
         self,
     ) -> dict[str, Collection]:
         """Return the latest collections."""
-        return await self._make_request(query=queries.me.LATEST_MEDIA)
+        query = queries.me.LATEST_MEDIA  # type: ignore[attr-defined]
+        return await self._make_request(query=query)
 
     @property
     def feeders(self) -> dict[str, Feeder]:

--- a/birdbuddy/exceptions.py
+++ b/birdbuddy/exceptions.py
@@ -12,18 +12,32 @@ class GraphqlError(Exception):
 
     response: dict
 
-    def __init__(self, error: dict) -> None:  # noqa: D107
+    def __init__(self, error: dict) -> None:
+        """Store the GraphQL error payload.
+
+        Args:
+            error: A single GraphQL error dict from the response.
+        """
         self.response = error
         super().__init__(f"{self.error_code}: {error}")
 
     @property
-    def error_code(self) -> int:
+    def error_code(self) -> str | None:
         """The Bird Buddy GraphQL error code."""
         return self.response.get("extensions", {}).get("code")
 
     @staticmethod
     def raise_errors(errors: list[dict]) -> None:
-        """Parse and raise errors as needed."""
+        """Raise the appropriate exception for a list of GraphQL errors.
+
+        Args:
+            errors: The ``errors`` list from a GraphQL response.
+
+        Raises:
+            GraphqlError: If exactly one error is present (as the most
+                specific subclass, e.g. ``AuthTokenExpiredError``).
+            CompositeException: If more than one error is present.
+        """
         converted = [GraphqlError._convert_error(err) for err in errors]
         if (n := len(converted)) == 0:
             return
@@ -33,6 +47,15 @@ class GraphqlError(Exception):
 
     @staticmethod
     def _convert_error(err: dict) -> Exception:
+        """Convert a GraphQL error dict to the most specific exception.
+
+        Args:
+            err: A single GraphQL error dict.
+
+        Returns:
+            An ``AuthTokenExpiredError`` for expired-token codes, otherwise a
+            ``GraphqlError``.
+        """
         gqlerr = GraphqlError(err)
         if gqlerr.error_code == AUTH_TOKEN_EXPIRED_ERROR:
             return AuthTokenExpiredError(err)
@@ -50,10 +73,19 @@ class AuthenticationFailedError(Exception):
 class UnexpectedResponseError(Exception):
     """The response did not contain the expected fields."""
 
-    def __init__(self, response: dict | None = None) -> None:  # noqa: D107
+    def __init__(self, response: dict | None = None) -> None:
+        """Store the unexpected response.
+
+        Args:
+            response: The raw GraphQL response, if available.
+        """
         Exception.__init__(self)
         self.response = response
 
 
-class CompositeException(Exception):
-    """Represents multiple errors."""
+class CompositeException(Exception):  # noqa: N818
+    """Represents multiple errors.
+
+    Named without an ``Error`` suffix for backwards compatibility; it is part
+    of the public API consumed by downstream packages.
+    """

--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections import UserDict
+from collections.abc import Iterator
 from datetime import datetime
 from enum import Enum
+from typing import Any, cast
 
 from propcache import cached_property
 
-from . import LOGGER
+from birdbuddy import LOGGER
 
 
 class FeedNodeType(Enum):
@@ -36,21 +38,28 @@ class FeedNodeType(Enum):
     """Sentinel value for an unexpected feed type."""
 
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: object) -> FeedNodeType:
         LOGGER.warning("Unexpected Feed type: %s", value)
         return FeedNodeType.Unknown
 
 
-class FeedNode(UserDict[str, any]):
+class FeedNode(UserDict[str, Any]):
     """A single Feed edge node."""
 
     _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
-    """The format string of GraphQL timestamps. This is not guaranteed to conform to
+    """The format string of GraphQL timestamps. Not guaranteed to conform to
     :func:`datetime.fromisoformat()`, so it has to be parsed manually."""
 
     @staticmethod
     def parse_datetime(timestr: str | None) -> datetime | None:
-        """Convert a time string into `datetime`."""
+        """Parse a GraphQL timestamp string into a datetime.
+
+        Args:
+            timestr: The timestamp string, or ``None``.
+
+        Returns:
+            The parsed ``datetime``, or ``None`` when ``timestr`` is ``None``.
+        """
         if timestr is None:
             return None
         if len(timestr) == 24:
@@ -74,11 +83,11 @@ class FeedNode(UserDict[str, any]):
         return FeedNode.parse_datetime(self.get("createdAt"))
 
 
-class FeedEdge(UserDict[str, any]):
+class FeedEdge(UserDict[str, Any]):
     """A single Feed edge."""
 
     @property
-    def cursor(self) -> str:
+    def cursor(self) -> str | None:
         """Feed edge cursor."""
         return self.get("cursor")
 
@@ -88,21 +97,21 @@ class FeedEdge(UserDict[str, any]):
         return FeedNode(self.get("node"))
 
 
-class Feed(UserDict[str, any]):
+class Feed(UserDict[str, Any]):
     """Representation of the Bird Buddy Feed items."""
 
     @property
-    def edges(self) -> list[FeedEdge]:
+    def edges(self) -> Iterator[FeedEdge]:
         """Returns all edges of the Feed."""
         return (FeedEdge(edge) for edge in self.get("edges", []))
 
     @property
-    def nodes(self) -> list[FeedNode]:
+    def nodes(self) -> Iterator[FeedNode]:
         """Returns all nodes of the Feed edges."""
         return (edge.node for edge in self.edges)
 
     @property
-    def page_end_cursor(self) -> str:
+    def page_end_cursor(self) -> str | None:
         """The cursor used to access the next (older) page of feed items."""
         return self.get("pageInfo", {}).get("endCursor", None)
 
@@ -111,16 +120,26 @@ class Feed(UserDict[str, any]):
         """Returns the newest `FeedEdge`, by `FeedNode.created_at`."""
         return max(
             (e for e in self.edges if e.node.created_at),
-            key=lambda edge: edge.node.created_at,
+            key=lambda edge: cast(datetime, edge.node.created_at),
             default=None,
         )
 
     def filter(
         self,
-        of_type: FeedNodeType | list[FeedNodeType] = None,
+        of_type: FeedNodeType | list[FeedNodeType] | None = None,
         newer_than: datetime | None = None,
     ) -> list[FeedNode]:
-        """Filter the feed by type or time."""
+        """Filter the feed by node type and/or recency.
+
+        Args:
+            of_type: Only include nodes of this type (or types); ``None``
+                includes all types.
+            newer_than: Only include nodes created after this time; ``None``
+                includes all times.
+
+        Returns:
+            The matching feed nodes.
+        """
         if isinstance(of_type, FeedNodeType):
             of_type = [of_type]
         return [

--- a/birdbuddy/feeder.py
+++ b/birdbuddy/feeder.py
@@ -1,9 +1,12 @@
 """Bird Buddy feeder models."""
 
+from __future__ import annotations
+
 from collections import UserDict
 from enum import Enum
+from typing import Any
 
-from . import LOGGER
+from birdbuddy import LOGGER
 
 
 class MetricState(Enum):
@@ -16,7 +19,7 @@ class MetricState(Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: object) -> MetricState:
         LOGGER.warning("Unexpected metric state: %s", value)
         return MetricState.UNKNOWN
 
@@ -31,7 +34,7 @@ class PowerProfile(Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: object) -> PowerProfile:
         LOGGER.warning("Unexpected power profile: %s", value)
         return PowerProfile.UNKNOWN
 
@@ -55,12 +58,12 @@ class FeederState(Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: object) -> FeederState:
         LOGGER.warning("Unexpected feeder.state: %s", value)
         return FeederState.UNKNOWN
 
 
-class Signal(UserDict[str, any]):
+class Signal(UserDict[str, Any]):
     """Wifi signal metrics."""
 
     @property
@@ -74,7 +77,7 @@ class Signal(UserDict[str, any]):
         return MetricState(self.get("state", "UNKNOWN"))
 
 
-class Battery(UserDict[str, any]):
+class Battery(UserDict[str, Any]):
     """Battery info."""
 
     @property
@@ -93,50 +96,50 @@ class Battery(UserDict[str, any]):
         return MetricState(self.get("state", "UNKNOWN"))
 
 
-class Feeder(UserDict[str, any]):
+class Feeder(UserDict[str, Any]):
     """Represents one Bird Buddy device."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a string representation of the Feeder."""
-        return f"<Feeder: {self.name}, {self.state}, " f"{self.battery.percentage}%>"
+        return f"<Feeder: {self.name}, {self.state}, {self.battery.percentage}%>"
 
     @property
-    def id(self):
+    def id(self) -> str:
         """UUID."""
         return self["id"]
 
     @property
-    def serial(self):
+    def serial(self) -> str:
         """Feeder SN."""
         return self["serialNumber"]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Feeder name, as set in the app."""
         return self.get("name", "Bird Buddy")
 
     @property
-    def is_owner(self):
+    def is_owner(self) -> bool:
         """Whether the logged in user is the owner of this feeder."""
         return self.get("__typename") == "FeederForOwner"
 
     @property
-    def is_pending(self):
-        """``True`` if waiting for the owner account to approve access to the Feeder."""
+    def is_pending(self) -> bool:
+        """``True`` if waiting for the owner account to approve access."""
         return self.get("__typename") == "FeederForMemberPending"
 
     @property
-    def is_public(self):
+    def is_public(self) -> bool:
         """Whether this is a public feeder."""
         return self.get("__typename") == "FeederForPublic"
 
     @property
-    def version(self) -> str:
+    def version(self) -> str | None:
         """Firmware version (owner only)."""
         return self.get("firmwareVersion")
 
     @property
-    def version_update_available(self) -> str:
+    def version_update_available(self) -> str | None:
         """Firmware update version (owner only)."""
         return self.get("availableFirmwareVersion", None)
 
@@ -146,17 +149,17 @@ class Feeder(UserDict[str, any]):
         return FeederState(self.get("state", "UNKNOWN"))
 
     @property
-    def is_off_grid(self) -> bool:
+    def is_off_grid(self) -> bool | None:
         """Whether `state` is `FeederState.OFF_GRID`."""
         return self.get("offGrid", None)
 
     @property
-    def is_audio_enabled(self) -> bool:
+    def is_audio_enabled(self) -> bool | None:
         """Whether videos will contain audio."""
         return self.get("audioEnabled", None)
 
     @property
-    def owner(self) -> str:
+    def owner(self) -> str | None:
         """The username who first paired the Feeder."""
         return self.get("ownerName")
 
@@ -207,7 +210,7 @@ class Feeder(UserDict[str, any]):
         return self.get("temperature", {}).get("value", 0)
 
 
-class FeederUpdateStatus(UserDict[str, any]):
+class FeederUpdateStatus(UserDict[str, Any]):
     """Feeder update status."""
 
     @property
@@ -234,11 +237,11 @@ class FeederUpdateStatus(UserDict[str, any]):
         return self["__typename"] == "FeederFirmwareUpdateFailedResult"
 
     @property
-    def failure_reason(self) -> str:
+    def failure_reason(self) -> str | None:
         """Failure reason, or `None` if no failure."""
         return self.get("failedReason", None)
 
     @property
-    def progress(self) -> int:
+    def progress(self) -> int | None:
         """Current firmware installation progress."""
         return self.get("progress", None)

--- a/birdbuddy/media.py
+++ b/birdbuddy/media.py
@@ -1,21 +1,23 @@
-"""Bird Buddy collections and media"""
+"""Bird Buddy collections and media."""
 
 from __future__ import annotations
+
 from collections import UserDict
 from datetime import datetime
 import time
-from urllib.parse import urlparse, parse_qs
+from typing import Any
+from urllib.parse import parse_qs, urlparse
 
-from .birds import Species
-from .feed import FeedNode
+from birdbuddy.birds import Species
+from birdbuddy.feed import FeedNode
 
 
-class Media(UserDict):
-    """Represents one ``MediaImage`` or ``MediaVideo`` type"""
+class Media(UserDict[str, Any]):
+    """Represents one ``MediaImage`` or ``MediaVideo`` type."""
 
     @property
     def id(self) -> str:
-        """The media id"""
+        """The media id."""
         return self["id"]
 
     @property
@@ -24,73 +26,81 @@ class Media(UserDict):
         return self["__typename"] == "MediaVideo"
 
     @property
-    def created_at(self) -> datetime:
-        """Creation timestamp"""
+    def created_at(self) -> datetime | None:
+        """Creation timestamp."""
         return FeedNode.parse_datetime(self["createdAt"])
 
     @property
     def thumbnail_url(self) -> str:
-        """Thumbnail URL"""
+        """Thumbnail URL."""
         return self["thumbnailUrl"]
 
     @property
-    def content_url(self) -> str:
-        """Large content URL"""
+    def content_url(self) -> str | None:
+        """Large content URL."""
         return self.get("contentUrl", None)
 
     @property
-    def is_expired(self) -> bool:
-        """`True` if the media URL is expired"""
+    def is_expired(self) -> bool | None:
+        """`True` if the media URL is expired."""
         return is_media_expired(self.thumbnail_url)
 
 
-def is_media_expired(media_url: str) -> bool:
-    """`True` if the media URL is expired"""
+def is_media_expired(media_url: str) -> bool | None:
+    """Report whether a signed media URL has expired.
+
+    Args:
+        media_url: A signed media URL carrying an ``Expires`` query param.
+
+    Returns:
+        ``True`` if expired, ``False`` if still valid, or ``None`` when the
+        URL is empty or carries no expiry.
+    """
     if not media_url:
         return None
-    expiry = int(parse_qs(urlparse(media_url).query).get("Expires", None).pop())
+    expiry = int(parse_qs(urlparse(media_url).query)["Expires"].pop())
     if not expiry:
         return None
     now = time.time()
     return expiry < now
 
 
-class Collection(UserDict):
+class Collection(UserDict[str, Any]):
     """Collection of media for a particular bird species."""
 
     @property
-    def bird_name(self) -> str:
-        """The bird species in this collection"""
+    def bird_name(self) -> str | None:
+        """The bird species in this collection."""
         return self.get("species", {}).get("name", None)
 
     @property
     def species(self) -> Species | None:
-        """The bird species of this collection"""
+        """The bird species of this collection."""
         if s := self.get("species", None):
             return Species(s)
         return None
 
     @property
     def collection_id(self) -> str:
-        """The collection ``UUID``"""
+        """The collection ``UUID``."""
         return self["id"]
 
     @property
     def total_visits(self) -> int:
-        """Total number of visits"""
+        """Total number of visits."""
         return int(self.get("visitsAllTime", 0))
 
     @property
-    def last_visit(self) -> datetime:
-        """Most recent visit time"""
+    def last_visit(self) -> datetime | None:
+        """Most recent visit time."""
         return FeedNode.parse_datetime(self["visitLastTime"])
 
     @property
     def feeder_name(self) -> str | None:
-        """The feeder that captured this cover"""
+        """The feeder that captured this cover."""
         return self["coverCollectionMedia"].get("feederName")
 
     @property
     def cover_media(self) -> Media:
-        """The cover media"""
+        """The cover media."""
         return Media(self["coverCollectionMedia"]["media"])

--- a/birdbuddy/queries/__init__.py
+++ b/birdbuddy/queries/__init__.py
@@ -1,6 +1,5 @@
-"""GraphQL query strings"""
+"""GraphQL query strings."""
 
-from . import auth
-from . import birds
-from . import feeder
-from . import me
+from birdbuddy.queries import auth, birds, feeder, me
+
+__all__ = ["auth", "birds", "feeder", "me"]

--- a/birdbuddy/queries/auth.py
+++ b/birdbuddy/queries/auth.py
@@ -1,4 +1,4 @@
-"""Authentication queries"""
+"""Authentication queries."""
 
 SIGN_IN = """
 mutation emailSignIn($emailSignInInput: EmailSignInInput!) {

--- a/birdbuddy/queries/birds.py
+++ b/birdbuddy/queries/birds.py
@@ -1,4 +1,4 @@
-"""Queries related to birds and sightings"""
+"""Queries related to birds and sightings."""
 
 POSTCARD_REANALYZE = """
 mutation ReanalyzePostcard($feedItemId: ID!) {

--- a/birdbuddy/queries/debug.py
+++ b/birdbuddy/queries/debug.py
@@ -1,3 +1,5 @@
+"""GraphQL introspection query for dumping the schema."""
+
 DUMP_SCHEMA = """
 fragment FullType on __Type {
   kind

--- a/birdbuddy/queries/feeder.py
+++ b/birdbuddy/queries/feeder.py
@@ -1,4 +1,4 @@
-"""Feeder queries"""
+"""Feeder queries."""
 
 TOGGLE_OFF_GRID = """
 mutation feederToggleOffGrid($feederId: ID!, $feederToggleOffGridInput: FeederToggleOffGridInput!) {

--- a/birdbuddy/queries/me.py
+++ b/birdbuddy/queries/me.py
@@ -1,4 +1,4 @@
-"""Queries related to the logged in user"""
+"""Queries related to the logged in user."""
 
 ME = """
 query me {

--- a/birdbuddy/sightings.py
+++ b/birdbuddy/sightings.py
@@ -1,32 +1,42 @@
-"""Data models relating to bird Sightings"""
+"""Data models relating to bird Sightings."""
 
 from __future__ import annotations
+
 import base64
 from collections import UserDict
 from dataclasses import dataclass
 from enum import Enum
 import json
 import logging
+from typing import Any, cast
 
-from . import LOGGER
-from .birds import Species
-from .media import Collection, Media
+from birdbuddy import LOGGER
+from birdbuddy.birds import Species
+from birdbuddy.media import Collection, Media
 
 
 class SightingFinishStrategy(Enum):
-    """Best option for finishing a sighting"""
+    """Best option for finishing a sighting."""
 
     RECOGNIZED = "recognized"
     BEST_GUESS = "best_guess"
     MYSTERY = "mystery"
 
-    def finish(self, data: dict = None) -> SightingFinishMod:
-        """Wrap the strategy with additional metadata if needed"""
+    def finish(self, data: dict | None = None) -> SightingFinishMod:
+        """Wrap the strategy with optional match data.
+
+        Args:
+            data: Extra match data, used only by ``BEST_GUESS``.
+
+        Returns:
+            A ``SightingFinishMod`` pairing this strategy with ``data``.
+        """
         if self == SightingFinishStrategy.BEST_GUESS:
             return SightingFinishMod(self, data)
         return SightingFinishMod(self)
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
+        """Order strategies as RECOGNIZED < BEST_GUESS < MYSTERY."""
         if self.__class__ is not other.__class__:
             return NotImplemented
         if self == SightingFinishStrategy.RECOGNIZED:
@@ -38,7 +48,7 @@ class SightingFinishStrategy(Enum):
 
 @dataclass
 class SightingFinishMod:
-    """Simple wrapper for SightingFinishStrategy that includes additional data"""
+    """Wrapper for SightingFinishStrategy that includes additional data."""
 
     strategy: SightingFinishStrategy
     data: dict | None = None
@@ -57,7 +67,7 @@ class SightingType(Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def _missing_(cls, value: str) -> SightingType:
+    def _missing_(cls, value: object) -> SightingType:
         LOGGER.warning("Unexpected Sighting type: %s", value)
         return SightingType.UNKNOWN
 
@@ -71,25 +81,28 @@ class SightingType(Enum):
 
     @property
     def is_unlocked(self) -> bool:
-        """Whether this is the first sighting of a species (unlocked a new species)."""
+        """Whether this is the first sighting of a species."""
         return self == SightingType.SPECIES_UNLOCKED
 
 
-class Sighting(UserDict[str, any]):
+class Sighting(UserDict[str, Any]):
     """A sighting from a postcard sighting report."""
 
     def __str__(self) -> str:
+        """Return a readable summary of the sighting."""
         return (
-            f"Sighting<type={self.sighting_type}, recognized={self.is_recognized}, "
+            f"Sighting<type={self.sighting_type}, "
+            f"recognized={self.is_recognized}, "
             f"unlocked={self.is_unlocked}, species={self.species}>"
         )
 
     def __repr__(self) -> str:
+        """Return the debug representation."""
         return f"{__class__.__name__}({super().__repr__()})"
 
     @property
     def id(self) -> str:
-        """Sighting ID"""
+        """Sighting ID."""
         return self["id"]
 
     @property
@@ -108,13 +121,13 @@ class Sighting(UserDict[str, any]):
         return self.sighting_type.is_unlocked
 
     @property
-    def species(self) -> Species | None:
-        """Species"""
+    def species(self) -> Species:
+        """Species."""
         return Species(self.get("species", {}))
 
     @property
     def suggestions(self) -> list[Collection]:
-        """Suggested species"""
+        """Suggested species."""
         return [
             Collection(s)
             for s in self.get("suggestions", [])
@@ -136,19 +149,20 @@ class Sighting(UserDict[str, any]):
         }
 
 
-class SightingReport(UserDict[str, any]):
-    """Sighting Report object"""
+class SightingReport(UserDict[str, Any]):
+    """Sighting Report object."""
 
     _BEST_GUESS_CONFIDENCE = 10
     """The minimum confidence necessary to finish by best-guess."""
 
     def __str__(self) -> str:
-        return (
-            f"SightingReport<sightings[{len(self.sightings)}]: "
-            f"modes={ {s.id: f for (s, f) in self.sighting_finishing_strategies().values()} }>"
-        )
+        """Return a readable summary of the report."""
+        modes = {s.id: f for (s, f) in self.sighting_finishing_strategies().values()}
+        count = len(self.sightings)
+        return f"SightingReport<sightings[{count}]: modes={modes}>"
 
     def __repr__(self) -> str:
+        """Return the debug representation."""
         return f"{__class__.__name__}({super().__repr__()})"
 
     @property
@@ -157,18 +171,26 @@ class SightingReport(UserDict[str, any]):
         return [Sighting(s) for s in self.get("sightings", [])]
 
     @property
-    def token(self) -> str:
-        """Sighting reportToken, to allow the server to associate the sighting data."""
+    def token(self) -> str | None:
+        """Report token, used by the server to associate sighting data."""
         return self.get("reportToken", None)
 
     def _decode_signed_token(self, signed: str) -> str:
-        # This is a signed payload. The string is made up of:
-        # "<base64-encoded signing header>.<base64-encoded json payload>.<base64-encoded signature bytes>"
-        # We ignore the header and signature, and decode payload as JSON.
+        """Extract the nested reportToken from a signed token.
+
+        The token is ``header.payload.signature`` (base64 parts); only the
+        JSON payload is decoded, and its nested ``reportToken`` is returned.
+
+        Args:
+            signed: The signed ``header.payload.signature`` token string.
+
+        Returns:
+            The nested reportToken, or ``""`` if it is absent.
+        """
         (header, b64payload, _sig) = signed.split(".")
         if LOGGER.isEnabledFor(logging.DEBUG):
-            header = base64.b64decode(header + "==", validate=False)
-            LOGGER.debug("Got signed reportToken: %s", header)
+            decoded = base64.b64decode(header + "==", validate=False)
+            LOGGER.debug("Got signed reportToken: %s", decoded)
         # Decode the payload section to a json string
         payload_json = base64.b64decode(b64payload + "==", validate=False).decode(
             "utf-8", "ignore"
@@ -176,7 +198,7 @@ class SightingReport(UserDict[str, any]):
         # Then decode the JSON string so we can extract the nested reportToken
         payload = json.loads(payload_json)
         if not (token := payload.get("reportToken", None)):
-            return {}
+            return ""
         return token
 
     @property
@@ -194,12 +216,17 @@ class SightingReport(UserDict[str, any]):
 
     def sighting_finishing_strategies(
         self,
-        confidence_threshold: int = None,
+        confidence_threshold: int | None = None,
     ) -> dict[str, tuple[Sighting, SightingFinishMod]]:
-        """Determine best finishing strategy for each sighting in this report.
+        """Determine the best finishing strategy for each sighting.
 
-        Response will be a dictionary with the `Sighting` as the key, and the
-        best `SightingFinishMod` for that `Sighting`.
+        Args:
+            confidence_threshold: Minimum confidence to accept a best-guess
+                match; defaults to ``_BEST_GUESS_CONFIDENCE``.
+
+        Returns:
+            A mapping of sighting id to its ``(Sighting, SightingFinishMod)``
+            pair.
         """
         if confidence_threshold is None:
             confidence_threshold = SightingReport._BEST_GUESS_CONFIDENCE
@@ -215,13 +242,16 @@ class SightingReport(UserDict[str, any]):
         # pylint: disable=invalid-name
         for s in self.sightings:
             if s.is_recognized:
-                strategies[s.id] = (s, SightingFinishStrategy.RECOGNIZED.finish())
+                strategies[s.id] = (
+                    s,
+                    SightingFinishStrategy.RECOGNIZED.finish(),
+                )
             elif recognized_species and s.sighting_type in [
                 SightingType.CANNOT_DECIDE,
                 SightingType.MYSTERY_VISITOR,
             ]:
-                # If there's a recognized species in the same report, override the best-guess
-                # or mystery visitor with the recognized species.
+                # If there's a recognized species in the same report, override
+                # best-guess/mystery with the recognized species.
                 item = {
                     "confidence": 100,
                     "speciesCode": recognized_species.id,
@@ -235,7 +265,8 @@ class SightingReport(UserDict[str, any]):
                 # Match sightings to highest confidence
                 for m, item in matches.items():
                     if (
-                        item and m in s.match_tokens
+                        item
+                        and m in s.match_tokens
                         and item["confidence"] >= confidence_threshold
                         and item["type"] == "BIRD"
                     ):
@@ -248,19 +279,20 @@ class SightingReport(UserDict[str, any]):
         return strategies
 
     @property
-    def highest_confidence_matches(self) -> dict[str, dict[str, any]]:
-        """Returns the `$matchToken`: `{$confidence, $speciesCode}` mapping for the highest
-        confidence.
+    def highest_confidence_matches(self) -> dict[str, dict[str, Any] | None]:
+        """Return the highest-confidence match per match token.
 
-        This can be used to select the highest confidence species match for each match token.
-        These match tokens will correspond to 'CannotDecide' sighting types."""
+        Maps `$matchToken` to `{$confidence, $speciesCode}`, used to select the
+        highest confidence species match for each match token. These match
+        tokens correspond to 'CannotDecide' sighting types.
+        """
         token = self.token_json
         if not token:
             LOGGER.warning("Cannot decode reportToken, falling back on .suggestions")
             return {
                 match_token: {
                     "confidence": SightingReport._BEST_GUESS_CONFIDENCE,
-                    "speciesCode": collection.species.id,
+                    "speciesCode": cast(Species, collection.species).id,
                     "type": "BIRD",
                 }
                 for s in self.sightings
@@ -268,8 +300,9 @@ class SightingReport(UserDict[str, any]):
                 and (collection := next(iter(s.suggestions), None))
             }
 
-        matches = {
-            # items should already be sorted by confidence, but make sure we only return BIRD items
+        return {
+            # items should already be sorted by confidence, but make sure we
+            # only return BIRD items
             i["matchToken"]: max(
                 (ii for ii in i["items"] if ii["type"] == "BIRD"),
                 key=lambda x: x["confidence"],
@@ -277,58 +310,66 @@ class SightingReport(UserDict[str, any]):
             )
             for i in token.get("reportItems", [])
         }
-        return matches
 
 
-class PostcardSighting(UserDict[str, any]):
+class PostcardSighting(UserDict[str, Any]):
     """Represents a bird sighting from a postcard.
 
-    See also `FeedNodeType.NewPostcard`, `BirdBuddy.sighting_from_postcard()`."""
+    See also `FeedNodeType.NewPostcard`, `BirdBuddy.sighting_from_postcard()`.
+    """
 
-    postcard_id: str = None
+    postcard_id: str | None = None
 
     def __repr__(self) -> str:
+        """Return the debug representation."""
         return f"{__class__.__name__}({super().__repr__()})"
 
     def __str__(self) -> str:
+        """Return a readable summary of the postcard sighting."""
         return f"PostcardSighting<feeder={self.feeder['name']}, report={self.report}>"
 
     @property
     def feeder(self) -> dict:
-        """Describes the Feeder this sighting happened at"""
+        """Describes the Feeder this sighting happened at."""
         return self.get("feeder", {})
 
     @property
     def medias(self) -> list[Media]:
-        """List of media for the sighting"""
+        """List of media for the sighting."""
         return [Media(m) for m in self.get("medias", [])]
 
     @property
     def video_media(self) -> list[Media]:
-        """List of Video media for the sighting"""
+        """List of Video media for the sighting."""
         return [Media(v)] if (v := self.get("videoMedia")) else []
 
     @property
     def report(self) -> SightingReport:
-        """Sighting report"""
+        """Sighting report."""
         return SightingReport(self.get("sightingReport", {}))
 
     def with_postcard(self, postcard_id: str) -> PostcardSighting:
-        """Initialize the source postcard id"""
+        """Record the source postcard id and return self.
+
+        Args:
+            postcard_id: The originating postcard feed-item id.
+
+        Returns:
+            This ``PostcardSighting`` (for chaining).
+        """
         self.postcard_id = postcard_id
         return self
 
 
-class SightingCreateProgress(UserDict[str, any]):
-    """Sighting Create Progress object"""
+class SightingCreateProgress(UserDict[str, Any]):
+    """Sighting Create Progress object."""
 
     @property
     def id(self) -> str:
-        """Sighting create ID"""
+        """Sighting create ID."""
         return self["id"]
 
     @property
     def progress(self) -> float:
-        """Progress percentage"""
+        """Progress percentage."""
         return float(self["progress"])
-

--- a/birdbuddy/user.py
+++ b/birdbuddy/user.py
@@ -1,22 +1,22 @@
-"""Bird Buddy user"""
+"""Bird Buddy user."""
 
 from collections import UserDict
 
 
 class BirdBuddyUser(UserDict):
-    """Bird Buddy user"""
+    """Bird Buddy user."""
 
     @property
     def id(self) -> str:
-        """User UUID"""
+        """User UUID."""
         return self["id"]
 
     @property
     def name(self) -> str:
-        """User name"""
+        """User name."""
         return self["name"]
 
     @property
     def avatar_url(self) -> str:
-        """User avatar"""
+        """User avatar."""
         return self["avatarUrl"]

--- a/dump_schema.py
+++ b/dump_schema.py
@@ -1,9 +1,11 @@
+"""Dump the Bird Buddy GraphQL schema to schema.json."""
+
 import asyncio
 import json
+from pathlib import Path
 
 from birdbuddy.client import BirdBuddy
 
 bb = BirdBuddy()
-# Redirect output to schema.txt file
-with open('schema.json', 'w') as f:
+with Path("schema.json").open("w") as f:
     json.dump(asyncio.run(bb.dump_schema()), f, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,16 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "coverage==7.0.5",
-    "pytest==7.2.1",
-    "pytest-cov==3.0.0",
-    "pytest-aiohttp==1.0.4",
-    "pytest-asyncio==0.20.2",
-    "pyyaml==6.0.2",
+    "pytest~=9.1",
+    "pytest-asyncio~=1.4",
+    "pytest-aiohttp~=1.1",
+    "pytest-cov~=7.1",
+    "coverage~=7.15",
+    "pyyaml>=6.0.3,<7",
+    "ruff~=0.15.20",
+    "pyright~=1.1.411",
+    "build~=1.5",
+    "twine~=6.2",
 ]
 
 [project.urls]
@@ -31,3 +35,98 @@ Homepage = "https://github.com/jhansche/pybirdbuddy"
 
 [tool.setuptools.packages.find]
 include = ["birdbuddy*"]
+
+# https://docs.astral.sh/ruff/configuration/
+[tool.ruff]
+# 88 is the default line length for both ruff and Black.
+# https://docs.astral.sh/ruff/settings/#line-length
+# https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+line-length = 88
+target-version = "py310"
+
+# https://docs.astral.sh/ruff/rules/
+[tool.ruff.lint]
+select = [
+    "E", "W",  # pycodestyle errors and warnings
+    "F",       # Pyflakes (unused imports, undefined names)
+    "I",       # isort (import sorting)
+    "ANN",     # flake8-annotations (type hints required)
+    "ASYNC",   # flake8-async (async/await best practices)
+    "B",       # flake8-bugbear (likely bugs and design problems)
+    "BLE",     # flake8-blind-except (no broad exception catching)
+    "C4",      # flake8-comprehensions
+    "EM",      # flake8-errmsg (exception message formatting)
+    "FA",      # flake8-future-annotations (require __future__ annotations)
+    "G",       # flake8-logging-format (no f-strings in logging)
+    "PIE",     # flake8-pie (unnecessary code patterns)
+    "T20",     # flake8-print (disallow print statements)
+    "PT",      # flake8-pytest-style (pytest conventions)
+    "SIM",     # flake8-simplify (simplification suggestions)
+    "ARG",     # flake8-unused-arguments (unused function args)
+    "PTH",     # flake8-use-pathlib (prefer pathlib over os.path)
+    "TID252",  # flake8-tidy-imports (no relative imports)
+    "TRY",     # tryceratops (exception handling best practices)
+    "N",       # pep8-naming (naming conventions)
+    "PLC",     # Pylint convention (includes import-outside-top-level)
+    "PLR0915", # Pylint too-many-statements
+    "S101",    # flake8-bandit assert (banned in source; allowed in tests)
+    "S110",    # flake8-bandit try-except-pass
+    "S112",    # flake8-bandit try-except-continue
+    "UP",      # pyupgrade
+    "D",       # pydocstyle
+]
+
+ignore = [
+    "D203",    # incompatible with D211 (no-blank-line-before-class)
+    "D213",    # incompatible with D212 (multi-line-summary-first-line)
+    "TRY003",  # long exception messages are fine
+]
+
+[tool.ruff.lint.pydocstyle]
+# Google-style docstrings so multi-line docstrings carry Args:/Returns:/Raises:.
+convention = "google"
+
+[tool.ruff.lint.pylint]
+max-statements = 40  # Google style guide recommends ~40 lines per function
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Ban ALL relative imports (including single-dot); require absolute paths.
+ban-relative-imports = "all"
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+# Relax the requirements for test files (one-line docstrings still required).
+"tests/*" = [
+    "ANN001",  # Missing type annotation for function argument
+    "ANN201",  # Missing return type annotation for public function
+    "ANN202",  # Missing return type annotation for private function
+    "ARG001",  # Unused function argument
+    "ARG002",  # Unused method argument
+    "ARG005",  # Unused lambda argument
+    "S101",    # asserts are expected in tests
+]
+# Dev/maintenance scripts may print progress and use dynamic Any helpers.
+"scripts/*" = ["T201", "ANN401"]
+# GraphQL query strings are long by nature; don't wrap the query text.
+"birdbuddy/queries/*" = ["E501"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = [
+    "-q",
+    "--cov=birdbuddy",
+    "--cov-report=term",
+    "--cov-report=html",
+    "--junit-xml=junit.xml",
+]
+
+[tool.coverage.run]
+source = ["birdbuddy"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ Homepage = "https://github.com/jhansche/pybirdbuddy"
 [tool.setuptools.packages.find]
 include = ["birdbuddy*"]
 
+[tool.setuptools.package-data]
+# Ship the PEP 561 marker so downstream type-checkers consume our annotations.
+birdbuddy = ["py.typed"]
+
 # https://docs.astral.sh/ruff/configuration/
 [tool.ruff]
 # 88 is the default line length for both ruff and Black.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,13 @@
+{
+  "pythonVersion": "3.10",
+  "exclude": ["**/__pycache__", "**/.*", "build", "dist", "venv"],
+  "reportIncompatibleVariableOverride": false,
+  "executionEnvironments": [
+    {
+      "root": "tests",
+      "extraPaths": ["."],
+      "reportTypedDictNotRequiredAccess": false,
+      "reportOptionalMemberAccess": false
+    }
+  ]
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for Bird Buddy"""
+"""Tests for Bird Buddy."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+"""Shared pytest fixtures for the birdbuddy test suite."""
+
+from collections.abc import Iterator
 import pathlib
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -9,21 +12,38 @@ from birdbuddy.client import BirdBuddy
 
 
 def load_fixture(filename: str) -> str:
+    """Read a fixture file from ``tests/fixtures`` and return its text.
+
+    Args:
+        filename: The fixture file name under ``tests/fixtures``.
+
+    Returns:
+        The file contents as text.
+    """
     return pathlib.Path(__file__).parent.joinpath("fixtures", filename).read_text()
 
 
 @pytest.fixture(name="issue_40")
 def issue_40_yaml_fixture() -> dict:
+    """Load the issue-40 postcard sighting fixture."""
     return yaml.load(load_fixture("issue-40.yaml"), Loader=yaml.Loader)
 
 
 @pytest.fixture(name="bbclient")
 def logged_in_client() -> BirdBuddy:
-    client = BirdBuddy("user@email", "passw0rd", refresh_token="refresh", access_token="access")
-    return client
+    """Return a BirdBuddy client pre-seeded with fake tokens."""
+    return BirdBuddy(
+        "user@email",
+        "passw0rd",
+        refresh_token="refresh",
+        access_token="access",
+    )
 
 
 @pytest.fixture(name="graphql_mock")
-def mock_graphql() -> AsyncMock:
-    with mock.patch('python_graphql_client.graphql_client.GraphqlClient.execute_async') as method:
+def mock_graphql() -> Iterator[AsyncMock]:
+    """Patch GraphqlClient.execute_async and yield the mock."""
+    with mock.patch(
+        "python_graphql_client.graphql_client.GraphqlClient.execute_async"
+    ) as method:
         yield method

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,8 @@
 """Tests for birdbuddy/exceptions.py."""
+
 import pytest
 
-from birdbuddy.exceptions import (
-    CompositeException,
-    GraphqlError,
-)
+from birdbuddy.exceptions import CompositeException, GraphqlError
 
 
 def _err(code: str = "INTERNAL_SERVER_ERROR", message: str = "boom") -> dict:
@@ -26,7 +24,7 @@ def test_raise_errors_empty_list_returns_none() -> None:
 
 
 def test_raise_errors_single_error_raises_graphqlerror() -> None:
-    """One error → raise it directly as GraphqlError, not CompositeException."""
+    """One error → raise GraphqlError directly, not CompositeException."""
     errors = [_err()]
     with pytest.raises(GraphqlError) as exc_info:
         GraphqlError.raise_errors(errors)
@@ -39,11 +37,13 @@ def test_raise_errors_single_error_raises_graphqlerror() -> None:
 
 
 def test_raise_errors_multiple_errors_raises_compositeexception() -> None:
-    """Regression: with the old `if errs := len(converted) == 0:` walrus-
-    precedence bug, `errs` was a bool and `errs > 1` was always False, so
-    the CompositeException branch was dead code and the function silently
-    raised only the first error (dropping the rest). This test fails against
-    the buggy code and passes against the fix."""
+    """Regression test for the walrus-precedence bug in raise_errors.
+
+    With the old `if errs := len(converted) == 0:`, `errs` was a bool and
+    `errs > 1` was always False, so the CompositeException branch was dead
+    code and only the first error was raised (dropping the rest). This fails
+    against the buggy code and passes against the fix.
+    """
     errors = [_err(message="first"), _err(message="second")]
     with pytest.raises(CompositeException) as exc_info:
         GraphqlError.raise_errors(errors)

--- a/tests/test_issue_40.py
+++ b/tests/test_issue_40.py
@@ -1,4 +1,6 @@
-from unittest.mock import AsyncMock, ANY, call
+"""Tests for postcard finishing strategies (regression for issue #40)."""
+
+from unittest.mock import ANY, AsyncMock, call
 
 import pytest
 
@@ -12,6 +14,7 @@ async def test_sighting_recognized_single(
     issue_40: dict,
     graphql_mock: AsyncMock,
 ):
+    """RECOGNIZED strategy finishes without extra identification calls."""
     # By default, no extra identification happens
     graphql_mock.side_effect = [
         # sightingReportPostcardFinish
@@ -49,15 +52,17 @@ async def test_sighting_best_guess(
     issue_40: dict,
     graphql_mock: AsyncMock,
 ):
+    """BEST_GUESS chooses the highest-confidence species, then finishes."""
     original_report = issue_40["sighting"]["sightingReport"]
-    # Remove the recognized sighting to test fallback behavior without recognized species
+    # Drop the recognized sighting to exercise the no-recognized fallback.
     original_report["sightings"] = [
-        s for s in original_report["sightings"]
+        s
+        for s in original_report["sightings"]
         if s["__typename"] != "SightingRecognizedBirdUnlocked"
     ]
     modified_report = original_report.copy()
     modified_report["reportToken"] = original_report["reportToken"] + ".altered"
-    # with BEST_GUESS strategy, we will attempt to choose the best species match
+    # BEST_GUESS attempts to choose the best species match.
     graphql_mock.side_effect = [
         # sightingChooseSpecies
         {
@@ -112,10 +117,11 @@ async def test_sighting_anomaly_correction(
     issue_40: dict,
     graphql_mock: AsyncMock,
 ):
+    """A recognized species is propagated to correct an anomaly."""
     original_report = issue_40["sighting"]["sightingReport"]
     modified_report = original_report.copy()
     modified_report["reportToken"] = original_report["reportToken"] + ".altered"
-    # with BEST_GUESS strategy, we will attempt to choose the best species match
+    # BEST_GUESS attempts to choose the best species match.
     graphql_mock.side_effect = [
         # sightingChooseSpecies
         {"data": {"sightingChooseSpecies": modified_report}},
@@ -148,8 +154,8 @@ async def test_sighting_anomaly_correction(
                     "sightingReportPostcardFinishInput": {
                         "defaultCoverMedia": [
                             {
-                                "mediaId": "e579818d-cb68-40d2-876c-fcfdf3483eb6",
-                                "speciesId": "35379866-a4c6-4991-a2af-e6da93eaec4f",
+                                "mediaId": "e579818d-cb68-40d2-876c-fcfdf3483eb6",  # noqa: E501
+                                "speciesId": "35379866-a4c6-4991-a2af-e6da93eaec4f",  # noqa: E501
                             }
                         ],
                         "notSelectedMediaIds": [],

--- a/tests/test_sighting_create.py
+++ b/tests/test_sighting_create.py
@@ -154,3 +154,10 @@ async def test_reanalyze_postcard(bbclient: BirdBuddy, graphql_mock: AsyncMock):
         },
         headers=ANY,
     )
+
+
+@pytest.mark.asyncio
+async def test_reanalyze_postcard_rejects_bad_type(bbclient: BirdBuddy):
+    """A non-str/FeedNode postcard raises TypeError before any request."""
+    with pytest.raises(TypeError):
+        await bbclient.reanalyze_postcard(123)  # type: ignore[arg-type]

--- a/tests/test_sighting_create.py
+++ b/tests/test_sighting_create.py
@@ -1,4 +1,7 @@
-from unittest.mock import AsyncMock, ANY
+"""Tests for sighting-create, progress-check, and reanalyze flows."""
+
+from unittest.mock import ANY, AsyncMock
+
 import pytest
 
 from birdbuddy.client import BirdBuddy
@@ -7,6 +10,7 @@ from birdbuddy.sightings import SightingCreateProgress, SightingReport
 
 @pytest.mark.asyncio
 async def test_sighting_create(bbclient: BirdBuddy, graphql_mock: AsyncMock):
+    """sighting_create returns a SightingCreateProgress from the response."""
     graphql_mock.side_effect = [
         {
             "data": {
@@ -41,6 +45,7 @@ async def test_sighting_create(bbclient: BirdBuddy, graphql_mock: AsyncMock):
 async def test_sighting_create_check_progress_in_progress(
     bbclient: BirdBuddy, graphql_mock: AsyncMock
 ):
+    """An in-progress check returns a SightingCreateProgress."""
     graphql_mock.side_effect = [
         {
             "data": {
@@ -76,6 +81,7 @@ async def test_sighting_create_check_progress_in_progress(
 async def test_sighting_create_check_progress_completed(
     bbclient: BirdBuddy, graphql_mock: AsyncMock
 ):
+    """A completed check returns a SightingReport."""
     graphql_mock.side_effect = [
         {
             "data": {
@@ -121,6 +127,7 @@ async def test_sighting_create_check_progress_completed(
 
 @pytest.mark.asyncio
 async def test_reanalyze_postcard(bbclient: BirdBuddy, graphql_mock: AsyncMock):
+    """reanalyze_postcard returns the updated feed item payload."""
     graphql_mock.side_effect = [
         {
             "data": {
@@ -147,4 +154,3 @@ async def test_reanalyze_postcard(bbclient: BirdBuddy, graphql_mock: AsyncMock):
         },
         headers=ANY,
     )
-


### PR DESCRIPTION
Split of https://github.com/jhansche/pybirdbuddy/pull/40, part 2 of 3. Per your review there, separating pure repo/tooling from linting/functional and test.

## Commits

The diff is on the large side because of the ruff formatting and type fixes, but this PR is scoped better than #40 was 😄. You might want to look at 50420dc, 795551c, bb180de, and 0732ac6 separately first (that's the _actual_ work, formatting was either automatically fixed by ruff, or hand-fixed in the case of lines that exceeded Black's 88 chars)

1. 50420dc Adopt the ruff/pyright/pytest toolchain — adds a `Makefile`, the `ruff`/`pyright`/`pytest`/`coverage` config, and the `markdownlint` config. Brings the `dev` extras in `pyproject.toml` up to the latest versions, resolving the failures in #43. Now `make test` runs the full format/lint/type check/test workflow.
2. 97291e5 Resolve all `ruff` and `pyright` findings; adopt Google-style docstrings — set max line length is to 88 (the ruff/Black default), switch to absolute imports, use Google-style docstrings, improve type annotations, and rewrite `assert`s in non-test code as explicit `raise`s. Ships a PEP 561 `py.typed` marker so downstream consumers can use our types.
3. 795551c Guard the postcard argument against an unbound local — `reanalyze_postcard`/`sighting_from_postcard` branched on `str`/`FeedNode`, leaving `postcard_id` unbound (`UnboundLocalError`) for any other input; adds an `else` that raises a clear `TypeError`, plus a test.
4. bb180de Restructure the README and document the dev workflow — clearer structure, adds status shields (version, license, build status, etc.)
5. 0732ac6 Gate CI and publish test results across Python 3.10–3.14 — replace the pytest-only workflow with `make deps` + `make test`. Uploads coverage reports as artifacts for individual CI runs. Extends the matrix to include Python 3.13 and 3.14.

## Testing
Ran `make test` on Python 3.10.20 (lowest supported runtime) — `ruff`, `ruff format --check`, `markdownlint` (0 issues), `pyright` (0 errors, 0 warnings), `pytest` (12 passed). Also ran tests locally against 3.12 and 3.14, but of course CI is the final arbiter for the matrix.