### PR TITLE
Rewrite Makefile to support older versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,30 @@
-SHELL = /bin/bash
+SHELL = /bin/bash -xe
 
 # Create the venv with the interpreter pinned in .python-version and install
 # the dev/test/publish toolchain from the [dev] extra.
 .PHONY: deps
-.ONESHELL:
 deps:
-	set -e
 	@echo "Setting up the Python environment..."
 	python3 -m venv venv
-	. venv/bin/activate
-	pip install -U pip
-	pip install -e '.[dev]'
+	venv/bin/pip install -U pip
+	venv/bin/pip install -e '.[dev]'
 	@echo "Dependencies installed."
 
 # Auto-fix formatting and lint issues.
 .PHONY: format
-.ONESHELL:
 format:
-	set -e
-	. venv/bin/activate
-	ruff format
-	ruff check --fix
+	venv/bin/ruff format
+	venv/bin/ruff check --fix
 
 # Full gate: format check, lint, type check, and the entire test suite.
 .PHONY: test
-.ONESHELL:
 test:
 	@echo "Running format check, lint, type check, and tests..."
-	set -e
-	. venv/bin/activate
-	ruff check
-	ruff format --check --diff
+	venv/bin/ruff check
+	venv/bin/ruff format --check --diff
 	npx -y markdownlint-cli2 "*.md"
-	pyright --venvpath . --warnings
-	python -m pytest
+	venv/bin/pyright --warnings
+	venv/bin/pytest tests/
 	@echo "All checks passed."
 
 # Alias for `make test`.
@@ -42,29 +33,20 @@ check: test
 
 # Refresh the committed GraphQL schema fixture from the live API.
 .PHONY: schema
-.ONESHELL:
 schema:
-	set -e
-	. venv/bin/activate
-	python scripts/dump_schema.py
+	venv/bin/python scripts/dump_schema.py
 
 # Build the sdist + wheel into dist/.
 .PHONY: build
-.ONESHELL:
 build:
-	set -e
-	. venv/bin/activate
 	rm -rf dist
-	python -m build
+	venv/bin/python -m build
 
 # Build then upload to PyPI (requires credentials/token).
 .PHONY: publish
-.ONESHELL:
 publish: build
-	set -e
-	. venv/bin/activate
-	twine check dist/*
-	twine upload dist/*
+	venv/bin/twine check dist/*
+	venv/bin/twine upload dist/*
 
 .PHONY: clean
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ birdbuddy = ["py.typed"]
 # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
 line-length = 88
 target-version = "py310"
-include = ["birdbuddy/**/*.py", "tests/**/*.py"]
+include = ["birdbuddy/**/*.py", "tests/**/*.py", "scripts/**/*.py"]
 
 # https://docs.astral.sh/ruff/rules/
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ birdbuddy = ["py.typed"]
 # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
 line-length = 88
 target-version = "py310"
+include = ["birdbuddy/**/*.py", "tests/**/*.py"]
 
 # https://docs.astral.sh/ruff/rules/
 [tool.ruff.lint]
@@ -127,6 +128,7 @@ addopts = [
     "--cov-report=html",
     "--junit-xml=junit.xml",
 ]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 source = ["birdbuddy"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,9 @@
 {
   "pythonVersion": "3.10",
+  "venvPath": ".",
+  "venv": "venv",
   "exclude": ["**/__pycache__", "**/.*", "build", "dist", "venv"],
+  "include": ["birdbuddy", "tests", "scripts"],
   "reportIncompatibleVariableOverride": false,
   "executionEnvironments": [
     {


### PR DESCRIPTION
`make` 3.82 is when `ONESHELL` was introduced, but the default version installed in macos (as of Tahoe 26) is 3.81. As a result the ONESHELL directives are ignored, and the `venv/bin/activate` inclusion is ineffective. There are 2 ways to work around that:
1. single shell, using `. venv/bin/activate && cmd1 && cmd2`, with backslashes for line continuation
2. keep shell commands separate, and invoke venv/bin/___ directly

Both approaches work (verified locally), but the venv/bin approach looks better, and removes an easy foot-gun.

This also tweaks other configs to ensure that rogue/scratch `.py` files don't get swept up in any of the checks