### PR TITLE
Fetch a NewPostcard's own media in the feed query

### DIFF
--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from collections import UserDict
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from propcache import cached_property
+
+if TYPE_CHECKING:
+    from birdbuddy.media import Media
 
 from birdbuddy import LOGGER
 
@@ -89,6 +92,34 @@ class FeedNode(UserDict[str, Any]):
     def created_at(self) -> datetime | None:
         """The `datetime` when the FeedNode item was created."""
         return FeedNode.parse_datetime(self.get("createdAt"))
+
+    @property
+    def feeder_id(self) -> str | None:
+        """The id of the feeder this item belongs to, when the item has one."""
+        return (self.get("feeder") or {}).get("id")
+
+    @property
+    def medias(self) -> list[Media]:
+        """The media attached to this feed item, newest first.
+
+        ``FeedItemNewPostcard`` and ``FeedItemCollectedPostcard`` both carry
+        their own media, so a caller does not need to convert a postcard into
+        a sighting just to get at its images.
+        """
+        # Imported here rather than at module scope: media.py imports FeedNode
+        # from this module, so a top-level import would be circular.
+        from birdbuddy.media import Media  # noqa: PLC0415
+
+        return sorted(
+            (Media(m) for m in self.get("medias") or []),
+            key=lambda m: m.created_at or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )
+
+    @property
+    def images(self) -> list[Media]:
+        """The still images attached to this feed item, newest first."""
+        return [m for m in self.medias if not m.is_video]
 
 
 class FeedEdge(UserDict[str, Any]):

--- a/birdbuddy/queries/me.py
+++ b/birdbuddy/queries/me.py
@@ -375,6 +375,31 @@ fragment MysteryVisitorResolvedFields on FeedItemMysteryVisitorResolved {
 }
 fragment NewPostcardFields on FeedItemNewPostcard {
   ...FeedItemFields
+  expiresAt
+  hasVideoMedia
+  mediaImageCount
+  inferenceType
+  inferenceExecutionMode
+  inferenceConfidenceLevel
+  reanalyzeAvailability
+  mediaSpeciesNameAssignmentAvailability
+  feeder {
+    ... on FeederForOwner {
+      id
+      name
+      __typename
+    }
+    ... on FeederForMember {
+      id
+      name
+      __typename
+    }
+    __typename
+  }
+  medias {
+    ...MediaFullFields
+    __typename
+  }
   __typename
 }
 """.strip()

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -78,3 +78,83 @@ def test_feed_newest_edge_and_filter():
     cutoff = datetime(2023, 2, 1, tzinfo=timezone.utc)
     recent = feed.filter(newer_than=cutoff)
     assert [n.node_id for n in recent] == ["n1"]
+
+
+def _postcard(**overrides: object) -> FeedNode:
+    """A NewPostcard node carrying two images and one video."""
+    node = {
+        "id": "p1",
+        "__typename": "FeedItemNewPostcard",
+        "createdAt": "2026-08-11T13:19:52.956Z",
+        "feeder": {"id": "feeder-1", "name": "Feeder", "__typename": "FeederForOwner"},
+        "medias": [
+            {
+                "id": "older-image",
+                "createdAt": "2026-08-11T12:24:19.693Z",
+                "thumbnailUrl": "https://example.test/old-thumb.jpg",
+                "contentUrl": "https://example.test/old.jpg",
+                "__typename": "MediaImage",
+            },
+            {
+                "id": "newer-image",
+                "createdAt": "2026-08-11T13:19:49.779Z",
+                "thumbnailUrl": "https://example.test/new-thumb.jpg",
+                "contentUrl": "https://example.test/new.jpg",
+                "__typename": "MediaImage",
+            },
+            {
+                "id": "video",
+                "createdAt": "2026-08-11T13:20:00.000Z",
+                "thumbnailUrl": "https://example.test/vid-thumb.jpg",
+                "__typename": "MediaVideo",
+            },
+        ],
+    }
+    node.update(overrides)
+    return FeedNode(node)
+
+
+def test_feed_node_medias_newest_first():
+    """Medias returns Media objects, newest first, video included."""
+    assert [m.id for m in _postcard().medias] == ["video", "newer-image", "older-image"]
+
+
+def test_feed_node_images_excludes_video():
+    """Images drops MediaVideo, keeping the newest-first ordering."""
+    images = _postcard().images
+    assert [m.id for m in images] == ["newer-image", "older-image"]
+    assert images[0].content_url == "https://example.test/new.jpg"
+
+
+def test_feed_node_feeder_id():
+    """feeder_id reads the embedded feeder, and tolerates its absence."""
+    assert _postcard().feeder_id == "feeder-1"
+    assert FeedNode({"id": "p2", "__typename": "FeedItemNewPostcard"}).feeder_id is None
+
+
+def test_feed_node_medias_absent_or_null():
+    """A node with no media -- or a null medias field -- yields no media."""
+    assert FeedNode({"id": "p3", "__typename": "FeedItemNewPostcard"}).medias == []
+    assert _postcard(medias=None).medias == []
+    assert _postcard(medias=[]).images == []
+
+
+def test_feed_node_medias_missing_created_at():
+    """Media with no createdAt still sorts, rather than raising."""
+    node = _postcard(
+        medias=[
+            {
+                "id": "no-date",
+                "createdAt": None,
+                "thumbnailUrl": "t",
+                "__typename": "MediaImage",
+            },
+            {
+                "id": "dated",
+                "createdAt": "2026-08-11T13:19:49.779Z",
+                "thumbnailUrl": "t",
+                "__typename": "MediaImage",
+            },
+        ]
+    )
+    assert [m.id for m in node.medias] == ["dated", "no-date"]


### PR DESCRIPTION
## Why

`FeedItemNewPostcard` carries its own `medias`, but `NewPostcardFields` selects
only `...FeedItemFields` — `id` and `createdAt`. So a caller holding a postcard
cannot see what is in it, and the only route to its images is
`sightingCreateFromPostcard`.

That has become load-bearing: the mutation is currently returning
`INTERNAL_SERVER_ERROR` from the Bird Buddy API
([ha-birdbuddy#98](https://github.com/jhansche/ha-birdbuddy/issues/98)), which
leaves consumers with no way to reach media the feed already had. The
downstream symptom is ha-birdbuddy's recent-visitor image stuck at `unknown`
since around April.

Selecting the fields the schema already offers removes that dependency for
reads. It does not attempt to fix the mutation, which is server-side.

## What

- **Widen `NewPostcardFields`** with `medias { ...MediaFullFields }`, the owning
  `feeder`, and the inference/`expiresAt`/`mediaImageCount` fields.
  `CollectedPostcardFields` already selects `medias` this way and
  `MediaFullFields` is defined in the same document, so this follows the
  existing shape rather than introducing one.
- **`FeedNode.medias` / `.images` / `.feeder_id`** so consumers do not hand-parse
  raw dicts. `medias` is newest-first; `images` drops `MediaVideo`. `Media` is
  imported lazily inside the property because `media.py` imports `FeedNode` from
  `feed.py` — a module-level import would be circular.

## Checks

- `tests/test_schema.py` validates the widened query against the committed
  2026-05 schema, so the drift guard covers this rather than my say-so.
- Five new tests for the accessors: ordering, video filtering, absent/null
  `medias`, missing `feeder`, and media with no `createdAt`.
- Full suite passes; `ruff check`, `ruff format` and `pyright` clean.
- Exercised against the live API on a real feeder: the widened query returns
  postcard media with usable `contentUrl`s.

## Disclosure

This was produced by an AI coding agent (Claude Code), driven and reviewed by
me. The live-API checks above are real, but they are one account over one
afternoon — worth a sceptical review rather than a rubber stamp.
