### PR TITLE
Paginate the feed and collections, align timestamp types, and deprecate dead methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ async def main():
     print(birds)
 ```
 
+## Deprecations
+
+Deprecated methods keep working and emit a `DeprecationWarning`, so upgrading
+does not break existing callers. Prefer the replacement:
+
+- `latest_collections()` — deprecated in 0.0.22; use `refresh_collections()`.
+  The old method referenced an undefined query and raised `AttributeError` on
+  every call, so it never returned data. It now delegates to
+  `refresh_collections()`, which returns the account's bird collections.
+
 ## Development
 
 Install [pyenv] and the pinned interpreter, then use the Makefile — every

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -475,7 +475,8 @@ class BirdBuddy:
         and an ``"edges"`` key with FeedEdge nodes, newest first.
 
         Args:
-            first: Return the first N items older than ``after``.
+            first: Return the first N items older than ``after``. Must be
+                1-100; the API returns an internal error for larger values.
             after: Cursor of the oldest item previously seen (pagination).
             last: Return the last N items newer than ``before``. Currently
                 ignored; the backward-pagination request path is disabled.
@@ -484,7 +485,11 @@ class BirdBuddy:
 
         Returns:
             The Feed.
+
+        Raises:
+            ValueError: If ``first`` is not between 1 and 100.
         """
+        _require_page_size(first)
         variables: dict[str, Any] = {
             # $first: Int,
             # $after: String,
@@ -506,49 +511,94 @@ class BirdBuddy:
         data = await self._make_request(query=queries.me.FEED, variables=variables)
         return Feed(data["me"]["feed"])
 
-    async def refresh_feed(
-        self,
-        since: datetime | str = _NO_VALUE,  # type: ignore[assignment]
-    ) -> list[FeedNode]:
-        """Return only feed items new since the last refresh.
+    def _feed_pages(self) -> AsyncIterator[dict]:
+        """Iterate feed connection pages, newest first, one per request."""
+        return self._iter_pages(
+            query=queries.me.FEED,
+            variables={"first": _MAX_PAGE_SIZE},
+            connection=lambda data: data["me"]["feed"],
+        )
 
-        The most recent edge node timestamp is saved as the last-seen feed
-        item, which becomes the new default value for ``since``. Useful to,
-        for example, restore a last-seen timestamp in a new instance.
+    def _note_newest_feed_date(self, feed: Feed) -> None:
+        """Advance the saved last-seen timestamp to a page's newest item.
 
         Args:
-            since: The time after which to restrict new feed items; defaults
-                to the last-seen timestamp.
-
-        Returns:
-            The new feed nodes.
+            feed: A feed page; its newest edge sets the last-seen timestamp.
         """
-        resolved = self._last_feed_date if since is _NO_VALUE else since
-        if isinstance(resolved, str):
-            resolved = FeedNode.parse_datetime(resolved)
-        feed = await self.feed()
-        if (newest_edge := feed.newest_edge) and (
-            newest_date := newest_edge.node.created_at
-        ) != self._last_feed_date:
+        if not (newest_edge := feed.newest_edge):
+            return
+        newest_date = newest_edge.node.created_at
+        if newest_date is not None and newest_date != self._last_feed_date:
             LOGGER.debug(
                 "Updating latest seen Feed timestamp: %s -> %s",
                 self._last_feed_date,
                 newest_date,
             )
             self._last_feed_date = newest_date
-        return feed.filter(newer_than=resolved)
+
+    async def refresh_feed(
+        self,
+        since: datetime | str = _NO_VALUE,  # type: ignore[assignment]
+    ) -> list[FeedNode]:
+        """Return only feed items new since the last refresh.
+
+        Pages backward through the feed (newest first) until it reaches
+        items no newer than ``since``, so more than one page of new items is
+        returned rather than truncated at the first page. The newest item's
+        timestamp is saved as the last-seen feed item, the new default for
+        ``since``.
+
+        With no ``since`` and no prior refresh there is no lower bound to
+        page toward, so only the most recent page is returned; this avoids
+        replaying the entire history on a first refresh.
+
+        Args:
+            since: The time after which to restrict new feed items; defaults
+                to the last-seen timestamp.
+
+        Returns:
+            The new feed nodes, newest first.
+        """
+        resolved = self._last_feed_date if since is _NO_VALUE else since
+        if isinstance(resolved, str):
+            resolved = FeedNode.parse_datetime(resolved)
+
+        if resolved is None:
+            feed = await self.feed()
+            self._note_newest_feed_date(feed)
+            return feed.filter(newer_than=None)
+
+        new_nodes: list[FeedNode] = []
+        noted = False
+        async for page in self._feed_pages():
+            feed = Feed(page)
+            if not noted:
+                self._note_newest_feed_date(feed)
+                noted = True
+            new_nodes.extend(feed.filter(newer_than=resolved))
+            oldest = min(
+                (n.created_at for n in feed.nodes if n.created_at),
+                default=None,
+            )
+            if oldest is not None and oldest <= resolved:
+                # Reached items no newer than the cutoff; older pages hold
+                # nothing new.
+                break
+        return new_nodes
 
     async def feed_nodes(self, node_type: FeedNodeType) -> list[FeedNode]:
-        """Return all feed items of the given type.
+        """Return all feed items of the given type across every page.
 
         Args:
             node_type: The feed node type to filter by.
 
         Returns:
-            The matching feed nodes.
+            The matching feed nodes, newest first.
         """
-        feed = await self.feed()
-        return feed.filter(of_type=node_type)
+        nodes: list[FeedNode] = []
+        async for page in self._feed_pages():
+            nodes.extend(Feed(page).filter(of_type=node_type))
+        return nodes
 
     async def new_postcards(self) -> list[FeedNode]:
         """Return all new 'Postcard' feed items.

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -17,6 +17,7 @@ from birdbuddy.exceptions import (
     AuthenticationFailedError,
     AuthTokenExpiredError,
     GraphqlError,
+    NoFirmwareUpdateAvailableError,
     NoResponseError,
     UnexpectedResponseError,
 )
@@ -1070,12 +1071,23 @@ class BirdBuddy:
 
         Returns:
             The firmware update status.
+
+        Raises:
+            NoFirmwareUpdateAvailableError: If the feeder already runs the
+                latest firmware (the API errors internally otherwise).
         """
         current_status = await self.update_firmware_check(feeder)
 
         if current_status.is_in_progress:
             # There's already an update in progress
             return current_status
+
+        # The API returns an internal error when asked to start an update that
+        # is not available, so guard on the versions the check reported.
+        reported = Feeder(current_status.get("feeder") or {})
+        if reported.version and reported.version == reported.version_update_available:
+            msg = f"feeder already on the latest firmware ({reported.version})"
+            raise NoFirmwareUpdateAvailableError(msg)
 
         feeder_id: str
         if isinstance(feeder, Feeder):

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import langcodes
 from python_graphql_client import GraphqlClient
+from typing_extensions import deprecated
 
 from birdbuddy import LOGGER, VERBOSE, queries
 from birdbuddy.const import BB_URL
@@ -1180,12 +1181,16 @@ class BirdBuddy:
                 result[node["id"]] = Media(node)
         return result
 
-    async def latest_collections(
-        self,
-    ) -> dict[str, Collection]:
-        """Return the latest collections."""
-        query = queries.me.LATEST_MEDIA  # type: ignore[attr-defined]
-        return await self._make_request(query=query)
+    @deprecated("latest_collections is deprecated; use refresh_collections()")
+    async def latest_collections(self) -> dict[str, Collection]:
+        """Return the account's bird collections.
+
+        Deprecated since 0.0.22; use :func:`refresh_collections` instead. The
+        previous implementation referenced an undefined query and raised
+        ``AttributeError`` on every call; this now delegates to
+        ``refresh_collections``, which keeps only bird collections.
+        """
+        return await self.refresh_collections()
 
     @property
     def feeders(self) -> dict[str, Feeder]:

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -313,7 +313,7 @@ class BirdBuddy:
                 ``edges`` and ``pageInfo``) from a response ``data`` dict.
 
         Yields:
-            Each page's connection object, oldest cursor first.
+            Each page's connection object, in natural iterating order.
         """
         after: str | None = None
         seen: set[str] = set()

--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator, Callable
 from datetime import datetime
 from typing import Any
 
@@ -35,10 +36,28 @@ from birdbuddy.user import BirdBuddyUser
 _NO_VALUE = object()
 """Sentinel value to allow None to override a default value."""
 
+_MAX_PAGE_SIZE = 100
+"""The largest page size the API accepts; a larger ``first`` errors server
+side (HTTP 200 with a GraphQL ``INTERNAL_SERVER_ERROR``)."""
+
 
 def _redact(data: object, redacted: bool = True) -> object:
     """Return a redacted string if necessary."""
     return "**REDACTED**" if redacted else data
+
+
+def _require_page_size(page_size: int) -> None:
+    """Validate a pagination page size.
+
+    Args:
+        page_size: The requested per-page item count.
+
+    Raises:
+        ValueError: If ``page_size`` is not between 1 and the API's limit.
+    """
+    if not 1 <= page_size <= _MAX_PAGE_SIZE:
+        msg = f"page size must be between 1 and {_MAX_PAGE_SIZE}"
+        raise ValueError(msg)
 
 
 class BirdBuddy:
@@ -268,6 +287,59 @@ class BirdBuddy:
         if subscript:
             return result[subscript]
         return result
+
+    async def _iter_pages(
+        self,
+        query: str,
+        variables: dict[str, Any],
+        connection: Callable[[dict], dict],
+    ) -> AsyncIterator[dict]:
+        """Yield successive pages of a Relay connection, following the cursor.
+
+        Requests ``query`` repeatedly, advancing ``after`` by the previous
+        page's ``endCursor`` until ``hasNextPage`` is false. Terminates
+        defensively if the server reports another page but returns no usable
+        cursor (missing, null, or one already seen), rather than looping
+        forever on a stuck cursor.
+
+        Args:
+            query: The GraphQL query text; it must accept an ``after`` cursor
+                and select ``pageInfo { hasNextPage endCursor }``.
+            variables: Base variables sent with every page (e.g. ``first``);
+                ``after`` is injected per page.
+            connection: Extracts the connection object (the one carrying
+                ``edges`` and ``pageInfo``) from a response ``data`` dict.
+
+        Yields:
+            Each page's connection object, oldest cursor first.
+        """
+        after: str | None = None
+        seen: set[str] = set()
+        while True:
+            page_vars = dict(variables)
+            if after is not None:
+                # The API errors on an explicit ``after: null``; omit it for
+                # the first page and only send a real cursor.
+                page_vars["after"] = after
+            data = await self._make_request(query=query, variables=page_vars)
+            page = connection(data)
+            yield page
+
+            page_info = page.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                return
+            cursor = page_info.get("endCursor")
+            if not cursor or cursor in seen:
+                # Defensive: the server claims another page but gave no new
+                # cursor to advance with. Stop instead of re-requesting.
+                LOGGER.debug(
+                    "Pagination stopped: hasNextPage but cursor did not "
+                    "advance (endCursor=%r)",
+                    cursor,
+                )
+                return
+            seen.add(cursor)
+            after = cursor
 
     @property
     def user(self) -> None | BirdBuddyUser:
@@ -1025,27 +1097,38 @@ class BirdBuddy:
                 del self._collections[collection.collection_id]
         return self._collections
 
-    async def collection(self, collection_id: str) -> dict[str, Media]:
-        """Return the media in the specified collection.
+    async def collection(
+        self, collection_id: str, page_size: int = 50
+    ) -> dict[str, Media]:
+        """Return all media in the specified collection.
+
+        Follows pagination so collections larger than one page are fully
+        retrieved (not truncated to the first page).
 
         Args:
             collection_id: The collection ``UUID``.
+            page_size: How many media to request per page. Must be 1-100; the
+                API returns an internal error for larger page sizes.
 
         Returns:
             A mapping of ``media_id`` to its ``Media``.
+
+        Raises:
+            ValueError: If ``page_size`` is not between 1 and 100.
         """
-        variables = {
-            "collectionId": collection_id,
-            # other inputs: first, orderBy, last, after, before
-        }
-        data = await self._make_request(
-            query=queries.me.COLLECTIONS_MEDIA, variables=variables
+        _require_page_size(page_size)
+        result: dict[str, Media] = {}
+        variables = {"collectionId": collection_id, "first": page_size}
+        pages = self._iter_pages(
+            query=queries.me.COLLECTIONS_MEDIA,
+            variables=variables,
+            connection=lambda data: data["collection"]["media"],
         )
-        # TODO: check [collection][media][pageInfo][hasNextPage]?
-        return {
-            (node := edge["node"]["media"])["id"]: Media(node)
-            for edge in data["collection"]["media"]["edges"]
-        }
+        async for media in pages:
+            for edge in media["edges"]:
+                node = edge["node"]["media"]
+                result[node["id"]] = Media(node)
+        return result
 
     async def latest_collections(
         self,

--- a/birdbuddy/exceptions.py
+++ b/birdbuddy/exceptions.py
@@ -70,6 +70,10 @@ class AuthenticationFailedError(Exception):
     """The login attempt failed."""
 
 
+class NoFirmwareUpdateAvailableError(Exception):
+    """A firmware update was requested but the feeder is already current."""
+
+
 class UnexpectedResponseError(Exception):
     """The response did not contain the expected fields."""
 

--- a/birdbuddy/feed.py
+++ b/birdbuddy/feed.py
@@ -6,7 +6,7 @@ from collections import UserDict
 from collections.abc import Iterator
 from datetime import datetime
 from enum import Enum
-from typing import Any, cast
+from typing import Any
 
 from propcache import cached_property
 
@@ -87,7 +87,11 @@ class FeedNode(UserDict[str, Any]):
 
     @property
     def created_at(self) -> datetime | None:
-        """The `datetime` when the FeedNode item was created."""
+        """The `datetime` when the item was created, or None if absent.
+
+        Feed items are ``AnyFeedItem`` union members; a member the query does
+        not select ``createdAt`` for carries no timestamp, hence ``None``.
+        """
         return FeedNode.parse_datetime(self.get("createdAt"))
 
 
@@ -125,12 +129,13 @@ class Feed(UserDict[str, Any]):
 
     @cached_property
     def newest_edge(self) -> FeedEdge | None:
-        """Returns the newest `FeedEdge`, by `FeedNode.created_at`."""
-        return max(
-            (e for e in self.edges if e.node.created_at),
-            key=lambda edge: cast(datetime, edge.node.created_at),
-            default=None,
-        )
+        """Return the newest `FeedEdge` by time, or None when all undated."""
+        dated = [
+            (created, edge)
+            for edge in self.edges
+            if (created := edge.node.created_at) is not None
+        ]
+        return max(dated, key=lambda pair: pair[0])[1] if dated else None
 
     def filter(
         self,

--- a/birdbuddy/feeder.py
+++ b/birdbuddy/feeder.py
@@ -36,6 +36,7 @@ class PowerProfile(Enum):
     """Feeder power profiles."""
 
     FRENZY = "FRENZY_MODE"
+    ULTRA_FRENZY = "ULTRA_FRENZY_MODE"
     POWER_SAVE = "POWER_SAVER_MODE"
     STANDARD = "STANDARD_MODE"
 

--- a/birdbuddy/media.py
+++ b/birdbuddy/media.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from birdbuddy.birds import Species
+from birdbuddy.exceptions import UnexpectedResponseError
 from birdbuddy.feed import FeedNode
 
 
@@ -26,9 +27,20 @@ class Media(UserDict[str, Any]):
         return self["__typename"] == "MediaVideo"
 
     @property
-    def created_at(self) -> datetime | None:
-        """Creation timestamp."""
-        return FeedNode.parse_datetime(self["createdAt"])
+    def created_at(self) -> datetime:
+        """Creation timestamp.
+
+        Returns:
+            The creation ``datetime``. ``createdAt`` is non-null in the
+            schema, so it is always present.
+
+        Raises:
+            UnexpectedResponseError: If ``createdAt`` is missing or null,
+                which the schema does not permit.
+        """
+        if (created := FeedNode.parse_datetime(self.get("createdAt"))) is None:
+            raise UnexpectedResponseError(self.data)
+        return created
 
     @property
     def thumbnail_url(self) -> str:
@@ -94,9 +106,20 @@ class Collection(UserDict[str, Any]):
         return int(self.get("visitsAllTime", 0))
 
     @property
-    def last_visit(self) -> datetime | None:
-        """Most recent visit time."""
-        return FeedNode.parse_datetime(self["visitLastTime"])
+    def last_visit(self) -> datetime:
+        """Most recent visit time.
+
+        Returns:
+            The last-visit ``datetime``. ``visitLastTime`` is non-null in the
+            schema, so it is always present.
+
+        Raises:
+            UnexpectedResponseError: If ``visitLastTime`` is missing or null,
+                which the schema does not permit.
+        """
+        if (visited := FeedNode.parse_datetime(self.get("visitLastTime"))) is None:
+            raise UnexpectedResponseError(self.data)
+        return visited
 
     @property
     def feeder_name(self) -> str | None:

--- a/birdbuddy/queries/me.py
+++ b/birdbuddy/queries/me.py
@@ -137,6 +137,11 @@ fragment FeedConnectionFields on FeedConnection {
   __typename
 }
 fragment AnyFeedItemFields on AnyFeedItem {
+  ... on FeedItem {
+    id
+    createdAt
+    __typename
+  }
   ... on FeedItemFeederInvitationConfirmed {
     ...FeederInvitationConfirmedFields
     __typename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "jhansche", email = "madcoder@gmail.com" }]
 dependencies = [
     "python-graphql-client",
     "langcodes",
+    "typing_extensions>=4.5",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,3 +253,95 @@ async def test_reanalyze_postcard_rejects_bad_type(bbclient: BirdBuddy):
     """A non-str/FeedNode postcard raises TypeError before any request."""
     with pytest.raises(TypeError):
         await bbclient.reanalyze_postcard(123)  # type: ignore[arg-type]
+
+
+def _collection_page(media_id: str, *, has_next: bool, cursor: str | None) -> dict:
+    """Build one meCollectionsMedia page carrying a single media edge."""
+    return {
+        "data": {
+            "collection": {
+                "media": {
+                    "edges": [
+                        {
+                            "node": {
+                                "media": {
+                                    "id": media_id,
+                                    "__typename": "MediaImage",
+                                }
+                            }
+                        }
+                    ],
+                    "pageInfo": {
+                        "hasNextPage": has_next,
+                        "endCursor": cursor,
+                    },
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_collection_paginates(bbclient: BirdBuddy, graphql_mock: AsyncMock):
+    """collection() follows pageInfo.endCursor until hasNextPage is false."""
+    graphql_mock.side_effect = [
+        _collection_page("m1", has_next=True, cursor="cursor-1"),
+        _collection_page("m2", has_next=False, cursor=None),
+    ]
+    result = await bbclient.collection("col-1")
+
+    assert set(result) == {"m1", "m2"}
+    assert graphql_mock.call_count == 2
+    first, second = graphql_mock.call_args_list
+    # First page must omit `after` entirely: the API errors on `after: null`.
+    assert "after" not in first.kwargs["variables"]
+    assert first.kwargs["variables"]["first"] == 50
+    assert second.kwargs["variables"]["after"] == "cursor-1"
+
+
+@pytest.mark.parametrize("page_size", [0, -1, 101, 1000])
+@pytest.mark.asyncio
+async def test_collection_rejects_bad_page_size(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, page_size: int
+):
+    """A page_size outside 1-100 raises before any request is made.
+
+    The API returns an internal error above 100 (observed limit); the
+    guard rejects it client-side instead of round-tripping to fail.
+    """
+    with pytest.raises(ValueError, match="between 1 and"):
+        await bbclient.collection("col-1", page_size=page_size)
+    graphql_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collection_stops_on_null_cursor(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """hasNextPage=True with a null endCursor terminates instead of looping.
+
+    Only one page is queued; if the cursor guard failed, the loop would
+    re-request and exhaust side_effect (StopIteration) rather than hang.
+    """
+    graphql_mock.side_effect = [
+        _collection_page("m1", has_next=True, cursor=None),
+    ]
+    result = await bbclient.collection("col-1")
+
+    assert set(result) == {"m1"}
+    assert graphql_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_collection_stops_on_repeated_cursor(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """A non-advancing (repeated) endCursor stops the loop after that page."""
+    graphql_mock.side_effect = [
+        _collection_page("m1", has_next=True, cursor="c1"),
+        _collection_page("m2", has_next=True, cursor="c1"),
+    ]
+    result = await bbclient.collection("col-1")
+
+    assert set(result) == {"m1", "m2"}
+    assert graphql_mock.call_count == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY, AsyncMock, call, patch
 import pytest
 
 from birdbuddy.client import BirdBuddy
+from birdbuddy.exceptions import NoFirmwareUpdateAvailableError
+from birdbuddy.feeder import Feeder
 from birdbuddy.sightings import (
     PostcardSighting,
     SightingCreateProgress,
@@ -497,3 +499,34 @@ async def test_new_postcards_paginates_all_pages(
 
     assert {n.node_id for n in result} == {"p1", "p2"}
     assert graphql_mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_update_firmware_start_guards_when_up_to_date(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """update_firmware_start refuses to start when no update is available.
+
+    Verified live: starting an update on an up-to-date feeder errors server
+    side, so the client guards on the versions the check reported and raises
+    instead of round-tripping.
+    """
+    fid = "f1"
+    bbclient._feeders[fid] = Feeder({"id": fid, "__typename": "FeederForOwner"})  # noqa: SLF001
+    graphql_mock.side_effect = [
+        {
+            "data": {
+                "feederFirmwareUpdateCheckProgress": {
+                    "__typename": "FeederFirmwareUpdateSucceededResult",
+                    "feeder": {
+                        "availableFirmwareVersion": "1.8.1",
+                        "firmwareVersion": "1.8.1",
+                    },
+                }
+            }
+        }
+    ]
+    with pytest.raises(NoFirmwareUpdateAvailableError):
+        await bbclient.update_firmware_start(fid)
+    # Only the check ran; the start mutation was never sent.
+    assert graphql_mock.call_count == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -345,3 +345,136 @@ async def test_collection_stops_on_repeated_cursor(
 
     assert set(result) == {"m1", "m2"}
     assert graphql_mock.call_count == 2
+
+
+def _fts(minute: int) -> str:
+    """A feed timestamp; a larger minute is a more recent item."""
+    return f"2026-07-08T10:{minute:02d}:00+00:00"
+
+
+def _feed_page(
+    nodes: list[tuple[str, str, int]], *, has_next: bool, cursor: str | None
+) -> dict:
+    """Build one meFeed page from (id, __typename, minute) node tuples."""
+    return {
+        "data": {
+            "me": {
+                "feed": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": node_id,
+                                "__typename": typename,
+                                "createdAt": _fts(minute),
+                            }
+                        }
+                        for node_id, typename, minute in nodes
+                    ],
+                    "pageInfo": {
+                        "hasNextPage": has_next,
+                        "endCursor": cursor,
+                    },
+                }
+            }
+        }
+    }
+
+
+_POSTCARD = "FeedItemNewPostcard"
+
+
+@pytest.mark.parametrize("first", [0, -1, 101, 500])
+@pytest.mark.asyncio
+async def test_feed_rejects_bad_first(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, first: int
+):
+    """feed(first=) outside 1-100 raises before any request (server cap)."""
+    with pytest.raises(ValueError, match="between 1 and"):
+        await bbclient.feed(first=first)
+    graphql_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_feed_paginates_to_cutoff(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """refresh_feed accumulates new items across pages up to `since`."""
+    graphql_mock.side_effect = [
+        _feed_page(
+            [("n7", _POSTCARD, 7), ("n6", _POSTCARD, 6), ("n5", _POSTCARD, 5)],
+            has_next=True,
+            cursor="c1",
+        ),
+        _feed_page(
+            [("n4", _POSTCARD, 4), ("n3", _POSTCARD, 3), ("n2", _POSTCARD, 2)],
+            has_next=False,
+            cursor=None,
+        ),
+    ]
+    result = await bbclient.refresh_feed(since=_fts(3))
+
+    # Everything strictly newer than minute 3, spanning both pages.
+    assert {n.node_id for n in result} == {"n7", "n6", "n5", "n4"}
+    assert graphql_mock.call_count == 2
+    # The second page carries the first page's endCursor.
+    assert graphql_mock.call_args_list[1].kwargs["variables"]["after"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_feed_stops_early_at_cutoff(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """refresh_feed stops once a page reaches items no newer than `since`."""
+    graphql_mock.side_effect = [
+        _feed_page(
+            [("n7", _POSTCARD, 7), ("n3", _POSTCARD, 3)],
+            has_next=True,
+            cursor="c1",
+        ),
+    ]
+    result = await bbclient.refresh_feed(since=_fts(5))
+
+    # Page 1 already reaches minute 3 (<= cutoff), so no second request.
+    assert {n.node_id for n in result} == {"n7"}
+    assert graphql_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_feed_without_since_returns_one_page(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """With no prior refresh, refresh_feed returns only the newest page."""
+    graphql_mock.side_effect = [
+        _feed_page(
+            [("n7", _POSTCARD, 7), ("n6", _POSTCARD, 6)],
+            has_next=True,
+            cursor="c1",
+        ),
+    ]
+    result = await bbclient.refresh_feed()
+
+    assert {n.node_id for n in result} == {"n7", "n6"}
+    assert graphql_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_new_postcards_paginates_all_pages(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """new_postcards collects NewPostcard items across every page."""
+    graphql_mock.side_effect = [
+        _feed_page(
+            [("p1", _POSTCARD, 7), ("x1", "FeedItemMediaLiked", 6)],
+            has_next=True,
+            cursor="c1",
+        ),
+        _feed_page(
+            [("p2", _POSTCARD, 5)],
+            has_next=False,
+            cursor=None,
+        ),
+    ]
+    result = await bbclient.new_postcards()
+
+    assert {n.node_id for n in result} == {"p1", "p2"}
+    assert graphql_mock.call_count == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 """Tests for the BirdBuddy client methods."""
 
-from unittest.mock import ANY, AsyncMock, call
+from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
 
@@ -345,6 +345,25 @@ async def test_collection_stops_on_repeated_cursor(
 
     assert set(result) == {"m1", "m2"}
     assert graphql_mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_latest_collections_delegates_and_warns(bbclient: BirdBuddy):
+    """latest_collections is deprecated and forwards to refresh_collections.
+
+    The former implementation referenced an undefined query and raised
+    AttributeError; it now delegates to the working method.
+    """
+    cached = {"col-1": ANY}
+    with (
+        patch.object(
+            bbclient, "refresh_collections", AsyncMock(return_value=cached)
+        ) as refresh,
+        pytest.deprecated_call(),
+    ):
+        result = await bbclient.latest_collections()
+    refresh.assert_awaited_once_with()
+    assert result is cached
 
 
 def _fts(minute: int) -> str:

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -13,7 +13,7 @@ def test_feed_node_type_known_and_unknown():
 
 
 def test_parse_datetime_none_and_formats():
-    """parse_datetime handles None, the 24-char feed format, and ISO."""
+    """parse_datetime returns None for None, and parses feed and ISO strings."""
     assert FeedNode.parse_datetime(None) is None
     feed_fmt = FeedNode.parse_datetime("2023-01-01T00:00:00.000Z")
     assert feed_fmt is not None

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 
 from birdbuddy.feed import Feed, FeedNode, FeedNodeType
+from birdbuddy.queries.me import FEED
 
 
 def test_feed_node_type_known_and_unknown():
@@ -78,3 +79,20 @@ def test_feed_newest_edge_and_filter():
     cutoff = datetime(2023, 2, 1, tzinfo=timezone.utc)
     recent = feed.filter(newer_than=cutoff)
     assert [n.node_id for n in recent] == ["n1"]
+
+
+def test_feed_node_created_at_absent_is_none():
+    """A feed node missing createdAt reports None rather than raising."""
+    node = FeedNode({"id": "x", "__typename": "FeedItemEditorsChoice"})
+    assert node.created_at is None
+
+
+def test_feed_query_requests_created_at_for_all_union_members():
+    """The FEED query selects createdAt on the FeedItem interface (#24).
+
+    An interface fragment covers every AnyFeedItem member, including types
+    not enumerated individually.
+    """
+    assert "... on FeedItem {" in FEED
+    interface = FEED.split("... on FeedItem {", 1)[1].split("}", 1)[0]
+    assert "createdAt" in interface

--- a/tests/test_feeder.py
+++ b/tests/test_feeder.py
@@ -18,6 +18,7 @@ from birdbuddy.feeder import (
     [
         (MetricState, "HIGH", MetricState.HIGH),
         (PowerProfile, "FRENZY_MODE", PowerProfile.FRENZY),
+        (PowerProfile, "ULTRA_FRENZY_MODE", PowerProfile.ULTRA_FRENZY),
         (FeederState, "READY_TO_STREAM", FeederState.READY_TO_STREAM),
     ],
 )

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,7 +1,11 @@
 """Basic tests for the birdbuddy.media models."""
 
+from datetime import datetime
 import time
 
+import pytest
+
+from birdbuddy.exceptions import UnexpectedResponseError
 from birdbuddy.media import Collection, Media, is_media_expired
 
 
@@ -34,8 +38,21 @@ def test_media_image_properties():
     assert media.is_video is False
     assert media.thumbnail_url == future_url
     assert media.content_url == "https://cdn.example/full.jpg"
-    assert media.created_at is not None
+    assert isinstance(media.created_at, datetime)
     assert media.is_expired is False
+
+
+def test_media_created_at_missing_raises():
+    """A schema-violating null/absent createdAt raises, not a bare TypeError."""
+    media = Media({"id": "m3", "__typename": "MediaImage"})
+    with pytest.raises(UnexpectedResponseError):
+        _ = media.created_at
+
+
+def test_collection_last_visit_missing_raises():
+    """A schema-violating null/absent visitLastTime raises, not a TypeError."""
+    with pytest.raises(UnexpectedResponseError):
+        _ = Collection({"id": "c3"}).last_visit
 
 
 def test_media_video_and_missing_content_url():
@@ -77,7 +94,7 @@ def test_collection_properties():
     assert collection.species is not None
     assert collection.species.id == "sp1"
     assert collection.total_visits == 5
-    assert collection.last_visit is not None
+    assert isinstance(collection.last_visit, datetime)
     assert collection.feeder_name == "Backyard"
     assert collection.cover_media.id == "m1"
 


### PR DESCRIPTION
First part of splitting #41 into something more reviewable.

## Summary

- **Paginate `collection()`** — follow the connection cursor to completion with a `page_size` guard (accepted values are between 1–100,, see https://github.com/jhansche/pybirdbuddy/issues/29#issuecomment-4920621681).
- **Paginate and guard the feed** — `refresh_feed` pages to the `since` cutoff; `feed_nodes` / `new_postcards` page fully.
- **Fix missing `created_at`** — an inline fragment on the `FeedItem` interface makes every `AnyFeedItem` member return `createdAt`, fixing the  `'>' not supported between NoneType and datetime` crash.
- **Type timestamps to the schema** — `Media.created_at` / `Collection.last_visit` return `datetime` (both are in the schema as `DateTime!`); `FeedNode.created_at` stays optional for the union case.
- **Deprecate `latest_collections`** — now  delegates to `refresh_collections`, replacing a method that raised `AttributeError` on every call. Added a deprecation notice to the README.
- **Add the `ULTRA_FRENZY` power profile** (`ULTRA_FRENZY_MODE`). _(Note: I've never seen this in practice, but it exists in the schema)_
- **Guard `update_firmware_start`** — raise `NoFirmwareUpdateAvailableError` when the feeder is already on the latest firmware.

Adds one runtime dependency, `typing_extensions>=4.5`, for the PEP 702 `@deprecated` decorator (`@deprecated` is in stdlib but only beginning with Python 3.13; `typing_extensions` supports Python >=3.10).

## Issue references

- Fixes #24 — feed items with no `created_at`.
- References #29 — the page-size guards resolve the `first > 100` internal errors; the postcard half follows in the next PR.
- Supersedes #38 — incorporated here, with attribution to @tombeaulah as a co-author... please close it after review/merge.

## Follow-ups (next PR)

- Harden `collection()` / `_iter_pages` malformed-response paths with `UnexpectedResponseError` and graphql-core schema validation of every query.
- The `postcardCollect` flow and deprecation of the sighting-report methods.

## Notes

I also considered tightening `parse_datetime()` to remove `None` when fixing the m issing `created_at` crash, but didn't want to break the contract. I think the `FeedItem` change alone will suffice here, but I'm happy to tighten that if you're okay with it.