### PR TITLE
Harden collection pagination and expand test coverage

### DIFF
--- a/birdbuddy/client.py
+++ b/birdbuddy/client.py
@@ -315,6 +315,10 @@ class BirdBuddy:
 
         Yields:
             Each page's connection object, in natural iterating order.
+
+        Raises:
+            UnexpectedResponseError: If a response lacks the expected
+                connection object.
         """
         after: str | None = None
         seen: set[str] = set()
@@ -325,7 +329,12 @@ class BirdBuddy:
                 # the first page and only send a real cursor.
                 page_vars["after"] = after
             data = await self._make_request(query=query, variables=page_vars)
-            page = connection(data)
+            try:
+                page = connection(data)
+            except (KeyError, TypeError) as err:
+                raise UnexpectedResponseError(data) from err
+            if not isinstance(page, dict):
+                raise UnexpectedResponseError(data)
             yield page
 
             page_info = page.get("pageInfo") or {}
@@ -1280,6 +1289,7 @@ class BirdBuddy:
 
         Raises:
             ValueError: If ``page_size`` is not between 1 and 100.
+            UnexpectedResponseError: If a page lacks the expected media edges.
         """
         _require_page_size(page_size)
         result: dict[str, Media] = {}
@@ -1290,9 +1300,12 @@ class BirdBuddy:
             connection=lambda data: data["collection"]["media"],
         )
         async for media in pages:
-            for edge in media["edges"]:
-                node = edge["node"]["media"]
-                result[node["id"]] = Media(node)
+            try:
+                for edge in media["edges"]:
+                    node = edge["node"]["media"]
+                    result[node["id"]] = Media(node)
+            except (KeyError, TypeError) as err:
+                raise UnexpectedResponseError(media) from err
         return result
 
     @deprecated("latest_collections is deprecated; use refresh_collections()")

--- a/scripts/dump_payloads.py
+++ b/scripts/dump_payloads.py
@@ -51,7 +51,14 @@ _TOKEN_KEYS = {"accessToken", "refreshToken", "token"}
 _EMAIL_KEYS = {"email", "memberEmail"}
 _NAME_KEYS = {"name", "feederName", "memberName", "ownerName"}
 _SERIAL_KEYS = {"serialNumber"}
-_URL_KEYS = {"avatarUrl", "contentUrl", "thumbnailUrl", "iconUrl", "mediaUrl"}
+_URL_KEYS = {
+    "avatarUrl",
+    "contentUrl",
+    "thumbnailUrl",
+    "iconUrl",
+    "mediaUrl",
+    "mapUrl",
+}
 _CITY_KEYS = {"city", "locationCity"}
 _COUNTRY_KEYS = {"country", "locationCountry"}
 
@@ -194,18 +201,29 @@ async def _collect() -> dict[str, Any]:
     await bb.refresh()
     out["feeders"] = {k: v.data for k, v in bb.feeders.items()}
 
-    # Read-only profile and collections, straight from the library's queries.
-    profile = await bb._make_request(query=queries.me.ME)
-    out["me"] = profile["me"]
-    collections = await bb._make_request(query=queries.me.COLLECTIONS)
-    out["collections"] = collections["me"]["collections"]
+    # Capture profile and collections via _capture so a server error lands in
+    # the dump instead of aborting before the postcard steps run.
+    profile = await _capture("me", bb._make_request(query=queries.me.ME), out)
+    if profile:
+        out["me"] = profile["me"]
+    collections = await _capture(
+        "collections", bb._make_request(query=queries.me.COLLECTIONS), out
+    )
+    if collections:
+        out["collections"] = collections["me"]["collections"]
 
     postcards = await bb.new_postcards()
     out["new_postcards"] = [p.data for p in postcards]
     if not postcards:
         return out
 
-    feed_item_id = postcards[0].node_id
+    # Collecting is an irreversible mutation, so it is opt-in: set
+    # BB_COLLECT_POSTCARD_ID to the feed-item id to collect. Unset (the
+    # default) keeps the run read-only. Reanalyze and collect target the same
+    # item, so opting in reanalyzes the postcard being collected.
+    collect_id = os.environ.get("BB_COLLECT_POSTCARD_ID")
+    feed_item_id = collect_id or postcards[0].node_id
+
     # Reanalyze is idempotent (the app's identify button); safe to always run.
     await _capture(
         "reanalyze",
@@ -218,10 +236,6 @@ async def _collect() -> dict[str, Any]:
     # Key the reanalyze capture by feed-item id, matching the fixture shape.
     out["reanalyze"] = {feed_item_id: out["reanalyze"]}
 
-    # Collecting is an irreversible mutation, so it is opt-in: set
-    # BB_COLLECT_POSTCARD_ID to the feed-item id to collect. Unset (the
-    # default) keeps the run read-only.
-    collect_id = os.environ.get("BB_COLLECT_POSTCARD_ID")
     if not collect_id:
         return out
     await _capture(
@@ -229,7 +243,7 @@ async def _collect() -> dict[str, Any]:
         bb._make_request(
             query=queries.birds.POSTCARD_COLLECT,
             variables={
-                "feedItemId": collect_id,
+                "feedItemId": feed_item_id,
                 "postcardCollectInput": {"share": False},
             },
         ),

--- a/scripts/dump_payloads.py
+++ b/scripts/dump_payloads.py
@@ -1,14 +1,19 @@
 """Dump real Bird Buddy payloads for building test fixtures (needs creds).
 
 Reads ``BB_EMAIL`` and ``BB_PASSWORD`` (a local ``.env`` is loaded via
-python-dotenv), logs in, and captures the feeders, new postcards, and the
-postcard collect flow. Each risky call is captured so a server error
-(e.g. the postcard ``INTERNAL_SERVER_ERROR``) lands in the dump rather than
-aborting the run. It writes two git-ignored files:
+python-dotenv), logs in, and captures the profile, collections, feeders, new
+postcards, and the postcard collect flow. Each risky call is captured so a
+server error (e.g. the postcard ``INTERNAL_SERVER_ERROR``) lands in the dump
+rather than aborting the run. It writes two git-ignored files:
 
 * ``birdbuddy_payload.dump.json`` -- the raw capture (real account data).
 * ``birdbuddy_payload.sanitized.json`` -- the same data with identifying
   values scrubbed, suitable for copying into ``tests/fixtures`` after review.
+
+By default the run is read-only: it reads the profile, collections and feed,
+and reanalyzes a postcard (running AI inference, exactly what the app's
+identify button does). It only collects a postcard, an irreversible change to
+your account, when ``BB_COLLECT_POSTCARD_ID`` names the feed-item to collect.
 
 Usage:
     Copy ``.env.example`` to ``.env`` and fill in your credentials (or export
@@ -172,21 +177,28 @@ async def _capture(label: str, coro: Any, out: dict[str, Any]) -> Any:
 
 
 async def _collect() -> dict[str, Any]:
-    """Log in and capture the postcard collect flow.
+    """Log in and capture the read-only profile plus the postcard collect flow.
 
-    Sends the library's own ``POSTCARD_REANALYZE`` and ``POSTCARD_COLLECT``
-    queries, so the fixture cannot drift from what the client actually issues.
-    Collecting is a real mutation; run against a throwaway/test account.
+    Reads the ME profile and collections, then sends the library's own
+    ``POSTCARD_REANALYZE`` query (and ``POSTCARD_COLLECT`` only when opted in
+    via ``BB_COLLECT_POSTCARD_ID``), so the fixtures cannot drift from what the
+    client actually issues.
 
     Returns:
-        A dict mapping each captured step (feeders, new_postcards, reanalyze,
-        postcard_collect) to its payload, or an ``{"error": ...}`` entry when
-        that step failed.
+        A dict mapping each captured step (feeders, me, collections,
+        new_postcards, reanalyze, and postcard_collect when opted in) to its
+        payload, or an ``{"error": ...}`` entry when that step failed.
     """
     bb = BirdBuddy(os.environ["BB_EMAIL"], os.environ["BB_PASSWORD"])
     out: dict[str, Any] = {}
     await bb.refresh()
     out["feeders"] = {k: v.data for k, v in bb.feeders.items()}
+
+    # Read-only profile and collections, straight from the library's queries.
+    profile = await bb._make_request(query=queries.me.ME)
+    out["me"] = profile["me"]
+    collections = await bb._make_request(query=queries.me.COLLECTIONS)
+    out["collections"] = collections["me"]["collections"]
 
     postcards = await bb.new_postcards()
     out["new_postcards"] = [p.data for p in postcards]
@@ -194,7 +206,7 @@ async def _collect() -> dict[str, Any]:
         return out
 
     feed_item_id = postcards[0].node_id
-    # Reanalyze first (idempotent), then collect; capture either path's error.
+    # Reanalyze is idempotent (the app's identify button); safe to always run.
     await _capture(
         "reanalyze",
         bb._make_request(
@@ -205,12 +217,19 @@ async def _collect() -> dict[str, Any]:
     )
     # Key the reanalyze capture by feed-item id, matching the fixture shape.
     out["reanalyze"] = {feed_item_id: out["reanalyze"]}
+
+    # Collecting is an irreversible mutation, so it is opt-in: set
+    # BB_COLLECT_POSTCARD_ID to the feed-item id to collect. Unset (the
+    # default) keeps the run read-only.
+    collect_id = os.environ.get("BB_COLLECT_POSTCARD_ID")
+    if not collect_id:
+        return out
     await _capture(
         "postcard_collect",
         bb._make_request(
             query=queries.birds.POSTCARD_COLLECT,
             variables={
-                "feedItemId": feed_item_id,
+                "feedItemId": collect_id,
                 "postcardCollectInput": {"share": False},
             },
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,12 @@ def collect_flow_fixture() -> dict:
     return load_json_fixture("collect_flow.json")
 
 
+@pytest.fixture(name="api_payloads")
+def api_payloads_fixture() -> dict:
+    """Load the sanitized real API payload fixture (2026-07 capture)."""
+    return load_json_fixture("api_payloads.json")
+
+
 @pytest.fixture(name="bbclient")
 def logged_in_client() -> BirdBuddy:
     """Return a BirdBuddy client pre-seeded with fake tokens."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def collect_flow_fixture() -> dict:
 
 @pytest.fixture(name="api_payloads")
 def api_payloads_fixture() -> dict:
-    """Load the sanitized real API payload fixture (2026-07 capture)."""
+    """Load the sanitized real API payload fixture."""
     return load_json_fixture("api_payloads.json")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def postcard_sighting_fixture() -> dict:
 
 @pytest.fixture(name="collect_flow")
 def collect_flow_fixture() -> dict:
-    """Load the sanitized collect-flow capture (2026-07)."""
+    """Load the sanitized collect-flow capture."""
     return load_json_fixture("collect_flow.json")
 
 

--- a/tests/fixtures/api_payloads.json
+++ b/tests/fixtures/api_payloads.json
@@ -1,0 +1,299 @@
+{
+  "me": {
+    "user": {
+      "avatarUrl": "https://example.invalid/asset",
+      "email": "owner@example.invalid",
+      "id": "be0be1d6-188b-5640-a53f-31328800425f",
+      "name": "Test Bird Buddy",
+      "signInType": "EMAIL",
+      "__typename": "User"
+    },
+    "settings": {
+      "notificationDisabled": null,
+      "__typename": "Settings"
+    },
+    "feeders": [
+      {
+        "battery": {
+          "charging": false,
+          "percentage": 94,
+          "state": "HIGH",
+          "__typename": "FeederMetricBattery"
+        },
+        "food": {
+          "state": "LOW",
+          "__typename": "FeederMetricFood"
+        },
+        "id": "33149978-ad92-5752-b6e5-1580b262ccf9",
+        "name": "Test Bird Buddy",
+        "signal": {
+          "state": "MEDIUM",
+          "value": -64,
+          "__typename": "FeederMetricSignal"
+        },
+        "state": "READY_TO_STREAM",
+        "temperature": {
+          "value": 0,
+          "__typename": "FeederMetricTemperature"
+        },
+        "__typename": "FeederForOwner",
+        "availableFirmwareVersion": "1.8.1",
+        "firmwareVersion": "1.8.1",
+        "serialNumber": "SN-TEST-0001",
+        "invitationsAvailable": 9,
+        "offGrid": false,
+        "audioEnabled": true,
+        "powerProfile": "STANDARD_MODE",
+        "presenceUpdatedAt": "2026-07-09T00:11:15.555Z",
+        "members": [],
+        "location": {
+          "city": "Testville",
+          "country": "US",
+          "__typename": "Location"
+        }
+      }
+    ],
+    "__typename": "Me"
+  },
+  "collections": [
+    {
+      "id": "679ee54c-36bd-569b-9e71-82dad0ffe4fa",
+      "coverCollectionMedia": {
+        "id": "ff85750b-8577-5522-a961-86ab678e2574",
+        "feederName": "Test Bird Buddy",
+        "liked": false,
+        "likes": 0,
+        "isShared": false,
+        "locationCity": "Testville",
+        "locationCountry": "US",
+        "owning": true,
+        "ownerName": "Tester",
+        "origin": "POSTCARD",
+        "media": {
+          "id": "ff85750b-8577-5522-a961-86ab678e2574",
+          "createdAt": "2025-02-23T18:35:36.055Z",
+          "thumbnailUrl": "https://example.invalid/asset",
+          "contentUrl": "https://example.invalid/asset",
+          "__typename": "MediaImage"
+        },
+        "__typename": "CollectionMedia"
+      },
+      "markedAsNew": false,
+      "visitsAllTime": 1,
+      "visitLastTime": "2025-02-23T19:18:45.160Z",
+      "previewMedia": [
+        {
+          "media": {
+            "thumbnailUrl": "https://example.invalid/asset",
+            "__typename": "MediaImage"
+          },
+          "__typename": "CollectionMedia"
+        }
+      ],
+      "__typename": "CollectionBird",
+      "species": {
+        "id": "de09fd32-9b8c-5949-9a45-049d8957049c",
+        "iconUrl": "https://example.invalid/asset",
+        "name": "Black-Capped Chickadee",
+        "__typename": "SpeciesBird",
+        "isUnofficialName": false,
+        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/6bc27d4e-9f1a-41dc-8316-2086a9f79022_Black-capped%20Chickadee%20%281%29.svg"
+      }
+    },
+    {
+      "id": "de48ab88-6cfb-5a21-86ef-918908fa3baa",
+      "coverCollectionMedia": {
+        "id": "a28237a9-5820-5e0e-aa68-66304f40e548",
+        "feederName": "Test Bird Buddy",
+        "liked": false,
+        "likes": 0,
+        "isShared": false,
+        "locationCity": "Testville",
+        "locationCountry": "US",
+        "owning": true,
+        "ownerName": "Tester",
+        "origin": "POSTCARD",
+        "media": {
+          "id": "a28237a9-5820-5e0e-aa68-66304f40e548",
+          "createdAt": "2025-02-22T19:21:35.272Z",
+          "thumbnailUrl": "https://example.invalid/asset",
+          "contentUrl": "https://example.invalid/asset",
+          "__typename": "MediaImage"
+        },
+        "__typename": "CollectionMedia"
+      },
+      "markedAsNew": false,
+      "visitsAllTime": 6,
+      "visitLastTime": "2025-02-25T20:21:46.240Z",
+      "previewMedia": [
+        {
+          "media": {
+            "thumbnailUrl": "https://example.invalid/asset",
+            "__typename": "MediaImage"
+          },
+          "__typename": "CollectionMedia"
+        }
+      ],
+      "__typename": "CollectionBird",
+      "species": {
+        "id": "9b520e99-3710-5a5d-8c1f-0f6a432c13d2",
+        "iconUrl": "https://example.invalid/asset",
+        "name": "Pine Siskin",
+        "__typename": "SpeciesBird",
+        "isUnofficialName": false,
+        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/a34bcd83-2d18-4d2a-8b97-2f591ff79985_Pine%20Siskin.svg"
+      }
+    },
+    {
+      "id": "1503d851-9f03-521e-95a8-0e26671e829d",
+      "coverCollectionMedia": {
+        "id": "28575835-7b65-5086-8a25-f47602a1fe54",
+        "feederName": "Test Bird Buddy",
+        "liked": false,
+        "likes": 0,
+        "isShared": false,
+        "locationCity": "Testville",
+        "locationCountry": "US",
+        "owning": true,
+        "ownerName": "Tester",
+        "origin": "POSTCARD",
+        "media": {
+          "id": "28575835-7b65-5086-8a25-f47602a1fe54",
+          "createdAt": "2025-02-22T16:49:42.906Z",
+          "thumbnailUrl": "https://example.invalid/asset",
+          "contentUrl": "https://example.invalid/asset",
+          "__typename": "MediaImage"
+        },
+        "__typename": "CollectionMedia"
+      },
+      "markedAsNew": false,
+      "visitsAllTime": 10,
+      "visitLastTime": "2025-08-10T06:38:48.795Z",
+      "previewMedia": [
+        {
+          "media": {
+            "thumbnailUrl": "https://example.invalid/asset",
+            "__typename": "MediaImage"
+          },
+          "__typename": "CollectionMedia"
+        }
+      ],
+      "__typename": "CollectionBird",
+      "species": {
+        "id": "fe0cee0d-05df-593c-8a34-0e2cddcfc50d",
+        "iconUrl": "https://example.invalid/asset",
+        "name": "House Finch",
+        "__typename": "SpeciesBird",
+        "isUnofficialName": false,
+        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/d8c20684-d366-4933-8ceb-4955ec9459a1_House%20Finch.svg"
+      }
+    },
+    {
+      "id": "6b91784e-fa49-5178-8bcc-8fa9f6c92885",
+      "coverCollectionMedia": {
+        "id": "63683b02-dcb6-5e89-867c-e874d1e3806a",
+        "feederName": "Test Bird Buddy",
+        "liked": false,
+        "likes": 0,
+        "isShared": false,
+        "locationCity": "Testville",
+        "locationCountry": "US",
+        "owning": true,
+        "ownerName": "Tester",
+        "origin": "POSTCARD",
+        "media": {
+          "id": "63683b02-dcb6-5e89-867c-e874d1e3806a",
+          "createdAt": "2025-02-26T21:20:17.587Z",
+          "thumbnailUrl": "https://example.invalid/asset",
+          "contentUrl": "https://example.invalid/asset",
+          "__typename": "MediaImage"
+        },
+        "__typename": "CollectionMedia"
+      },
+      "markedAsNew": false,
+      "visitsAllTime": 3,
+      "visitLastTime": "2025-02-26T21:47:12.588Z",
+      "previewMedia": [
+        {
+          "media": {
+            "thumbnailUrl": "https://example.invalid/asset",
+            "__typename": "MediaImage"
+          },
+          "__typename": "CollectionMedia"
+        }
+      ],
+      "__typename": "CollectionBird",
+      "species": {
+        "id": "8ec96be4-a8a2-5a3d-9003-be179dc9353a",
+        "iconUrl": "https://example.invalid/asset",
+        "name": "Red-Breasted Nuthatch",
+        "__typename": "SpeciesBird",
+        "isUnofficialName": false,
+        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/bd6ef12e-955d-488c-af4e-c5462d6979aa_Red-Breasted%20Nuthatch.svg"
+      }
+    },
+    {
+      "id": "80d6e8fb-6dfb-56e0-ab08-a2723c5850ed",
+      "coverCollectionMedia": {
+        "id": "7f839866-d341-5e17-a2ef-846c69e159bb",
+        "feederName": "Test Bird Buddy",
+        "liked": false,
+        "likes": 0,
+        "isShared": false,
+        "locationCity": "Testville",
+        "locationCountry": "US",
+        "owning": true,
+        "ownerName": "Tester",
+        "origin": "POSTCARD",
+        "media": {
+          "id": "7f839866-d341-5e17-a2ef-846c69e159bb",
+          "createdAt": "2025-02-24T21:59:09.843Z",
+          "thumbnailUrl": "https://example.invalid/asset",
+          "contentUrl": "https://example.invalid/asset",
+          "__typename": "MediaImage"
+        },
+        "__typename": "CollectionMedia"
+      },
+      "markedAsNew": false,
+      "visitsAllTime": 5,
+      "visitLastTime": "2025-08-10T06:38:48.795Z",
+      "previewMedia": [
+        {
+          "media": {
+            "thumbnailUrl": "https://example.invalid/asset",
+            "__typename": "MediaImage"
+          },
+          "__typename": "CollectionMedia"
+        }
+      ],
+      "__typename": "CollectionMysteryVisitor"
+    }
+  ],
+  "new_postcards": [
+    {
+      "id": "91c2524c-233f-516f-8a4c-58e077085c62",
+      "createdAt": "2026-07-09T01:10:56.363Z",
+      "__typename": "FeedItemNewPostcard"
+    },
+    {
+      "id": "244eb9b5-9d50-531b-83a2-a7e1a2bb875d",
+      "createdAt": "2026-07-08T17:48:43.424Z",
+      "__typename": "FeedItemNewPostcard"
+    },
+    {
+      "id": "2b549742-86c5-5190-9211-7caeaad6a680",
+      "createdAt": "2026-07-08T13:31:08.961Z",
+      "__typename": "FeedItemNewPostcard"
+    },
+    {
+      "id": "20bfaced-bc61-5671-a6f5-e45b2049dbca",
+      "createdAt": "2026-07-08T12:49:05.221Z",
+      "__typename": "FeedItemNewPostcard"
+    },
+    {
+      "id": "951a8f75-2276-5fe4-82d2-573eda498ab2",
+      "createdAt": "2026-07-07T23:40:41.241Z",
+      "__typename": "FeedItemNewPostcard"
+    }
+  ]
+}

--- a/tests/fixtures/api_payloads.json
+++ b/tests/fixtures/api_payloads.json
@@ -97,7 +97,7 @@
         "name": "Black-Capped Chickadee",
         "__typename": "SpeciesBird",
         "isUnofficialName": false,
-        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/6bc27d4e-9f1a-41dc-8316-2086a9f79022_Black-capped%20Chickadee%20%281%29.svg"
+        "mapUrl": "https://example.invalid/asset"
       }
     },
     {
@@ -141,7 +141,7 @@
         "name": "Pine Siskin",
         "__typename": "SpeciesBird",
         "isUnofficialName": false,
-        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/a34bcd83-2d18-4d2a-8b97-2f591ff79985_Pine%20Siskin.svg"
+        "mapUrl": "https://example.invalid/asset"
       }
     },
     {
@@ -185,7 +185,7 @@
         "name": "House Finch",
         "__typename": "SpeciesBird",
         "isUnofficialName": false,
-        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/d8c20684-d366-4933-8ceb-4955ec9459a1_House%20Finch.svg"
+        "mapUrl": "https://example.invalid/asset"
       }
     },
     {
@@ -229,7 +229,7 @@
         "name": "Red-Breasted Nuthatch",
         "__typename": "SpeciesBird",
         "isUnofficialName": false,
-        "mapUrl": "https://assets.cms-api-graphql.cms-api.prod.aws.mybirdbuddy.com/asset/map/bird/bd6ef12e-955d-488c-af4e-c5462d6979aa_Red-Breasted%20Nuthatch.svg"
+        "mapUrl": "https://example.invalid/asset"
       }
     },
     {

--- a/tests/test_api_payloads.py
+++ b/tests/test_api_payloads.py
@@ -1,0 +1,57 @@
+"""Tests exercising the models against a sanitized real API payload.
+
+``tests/fixtures/api_payloads.json`` is a sanitized capture of live responses
+(2026-07) produced by ``scripts/dump_payloads.py``: identifying values are
+replaced, structure and enum values are preserved. These tests pin the current
+API shapes the models parse.
+"""
+
+from birdbuddy.feed import FeedNode, FeedNodeType
+from birdbuddy.feeder import Feeder, FeederState, MetricState, PowerProfile
+from birdbuddy.postcards import PostcardAnalysis
+
+
+def test_owner_feeder_parses_from_real_payload(api_payloads):
+    """The owner feeder in the ME payload parses into the model values."""
+    feeder = Feeder(api_payloads["me"]["feeders"][0])
+    assert feeder.is_owner is True
+    assert feeder.name == "Test Bird Buddy"
+    assert feeder.state is FeederState.READY_TO_STREAM
+    assert feeder.battery.percentage == 94
+    assert feeder.battery.state is MetricState.HIGH
+    assert feeder.signal.rssi == -64
+    assert feeder.signal.state is MetricState.MEDIUM
+    assert feeder.power_profile is PowerProfile.STANDARD
+    # FeederForOwner nests location as location{city,country}.
+    assert feeder.location == ("Testville", "US")
+
+
+def test_new_postcards_parse_as_feed_nodes(api_payloads):
+    """The captured new-postcard feed items parse as NewPostcard nodes."""
+    postcards = api_payloads["new_postcards"]
+    assert len(postcards) == 5
+    node = FeedNode(postcards[0])
+    assert node.node_type is FeedNodeType.NewPostcard
+    assert node.created_at is not None
+
+
+def test_identify_postcard_parses_analysis(collect_flow):
+    """An identified postcard yields species + media WITHOUT collecting.
+
+    The ``reanalyze`` block is captured with the library's own
+    ``POSTCARD_REANALYZE`` query, so this pins the exact shape
+    ``identify_postcard`` returns.
+    """
+    entry = next(iter(collect_flow["reanalyze"].values()))
+    item = entry["inferenceExternalPostcardReanalyze"]["updatedFeedItem"]
+    analysis = PostcardAnalysis(item)
+    # Recognized species come from the sighting-report preview (no collect).
+    assert analysis.species
+    assert all(s.name for s in analysis.species)
+    # Media resolves a content URL (a sanitized placeholder in the fixture).
+    assert analysis.medias
+    assert analysis.medias[0].content_url
+    # Feeder attribution + inference metadata are present.
+    assert analysis.feeder is not None
+    assert analysis.feeder.id
+    assert analysis.inference_execution_mode == "MANUAL_COMPLETED"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -318,6 +318,38 @@ async def test_collection_stops_on_repeated_cursor(
 
 
 @pytest.mark.asyncio
+async def test_collection_missing_connection_raises(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """A response without the collection/media connection raises."""
+    graphql_mock.side_effect = [{"data": {}}]
+    with pytest.raises(UnexpectedResponseError):
+        await bbclient.collection("col-1")
+
+
+@pytest.mark.asyncio
+async def test_collection_null_connection_raises(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """A null media connection raises instead of an AttributeError."""
+    graphql_mock.side_effect = [{"data": {"collection": {"media": None}}}]
+    with pytest.raises(UnexpectedResponseError):
+        await bbclient.collection("col-1")
+
+
+@pytest.mark.asyncio
+async def test_collection_malformed_edges_raises(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock
+):
+    """A page missing the expected media edges raises."""
+    graphql_mock.side_effect = [
+        {"data": {"collection": {"media": {"pageInfo": {"hasNextPage": False}}}}}
+    ]
+    with pytest.raises(UnexpectedResponseError):
+        await bbclient.collection("col-1")
+
+
+@pytest.mark.asyncio
 async def test_latest_collections_delegates_and_warns(bbclient: BirdBuddy):
     """latest_collections is deprecated and forwards to refresh_collections.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,13 @@
 """Tests for the BirdBuddy client methods."""
 
+import copy
 from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
 
 from birdbuddy.client import BirdBuddy
 from birdbuddy.exceptions import NoFirmwareUpdateAvailableError, UnexpectedResponseError
-from birdbuddy.feeder import Feeder
+from birdbuddy.feeder import Feeder, PowerProfile
 from birdbuddy.postcards import CollectedPostcard, PostcardAnalysis
 from birdbuddy.sightings import PostcardSighting, SightingFinishStrategy
 
@@ -598,3 +599,174 @@ async def test_collect_postcard_unexpected_response(
     graphql_mock.side_effect = [_REANALYZED, {"data": {}}]
     with pytest.raises(UnexpectedResponseError):
         await bbclient.collect_postcard(_PID)
+
+
+@pytest.mark.asyncio
+async def test_refresh_populates_user_and_feeders(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, api_payloads: dict
+):
+    """refresh() parses the ME payload into the user and feeder cache."""
+    graphql_mock.side_effect = [{"data": {"me": api_payloads["me"]}}]
+    assert await bbclient.refresh() is True
+    assert bbclient.user is not None
+    fid = api_payloads["me"]["feeders"][0]["id"]
+    assert fid in bbclient.feeders
+    assert bbclient.feeders[fid].is_owner is True
+
+
+@pytest.mark.asyncio
+async def test_login_parses_auth_and_profile(
+    graphql_mock: AsyncMock, api_payloads: dict
+):
+    """A fresh client signs in, stores tokens, and saves the profile."""
+    bb = BirdBuddy("user@email", "passw0rd")  # no tokens -> login required
+    sign_in = {
+        "data": {
+            "authEmailSignIn": {
+                "__typename": "Auth",
+                "accessToken": "acc",
+                "refreshToken": "ref",
+                "me": api_payloads["me"],
+            }
+        }
+    }
+    graphql_mock.side_effect = [sign_in, {"data": {"me": api_payloads["me"]}}]
+    assert await bb.refresh() is True
+    assert bb._access_token == "acc"
+    assert bb.user is not None
+    assert len(bb.feeders) == 1
+    assert graphql_mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_exchanges_refresh_token(
+    graphql_mock: AsyncMock, api_payloads: dict
+):
+    """With only a refresh token, the client exchanges it before requesting."""
+    bb = BirdBuddy("user@email", "passw0rd", refresh_token="old-refresh")
+    refreshed = {
+        "data": {
+            "authRefreshToken": {
+                "accessToken": "new-acc",
+                "refreshToken": "new-ref",
+            }
+        }
+    }
+    graphql_mock.side_effect = [
+        refreshed,
+        {"data": {"me": api_payloads["me"]}},
+    ]
+    await bb.refresh()
+    assert bb._access_token == "new-acc"
+    assert bb._refresh_token == "new-ref"
+
+
+@pytest.mark.asyncio
+async def test_refresh_collections_keeps_only_birds(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, api_payloads: dict
+):
+    """refresh_collections keeps CollectionBird and keys by collection id."""
+    graphql_mock.side_effect = [
+        {"data": {"me": {"collections": api_payloads["collections"]}}}
+    ]
+    result = await bbclient.refresh_collections()
+    # The fixture holds 4 CollectionBird + 1 CollectionMysteryVisitor.
+    assert len(result) == 4
+    assert all(c["__typename"] == "CollectionBird" for c in result.values())
+
+
+@pytest.mark.asyncio
+async def test_set_feeder_options_filters_unknown_keys(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, api_payloads: dict
+):
+    """set_feeder_options sends only recognized keys and caches the result.
+
+    Response shape matches the SET_OPTIONS selection set (FeederForOwner).
+    """
+    feeder_data = api_payloads["me"]["feeders"][0]
+    fid = feeder_data["id"]
+    bbclient._feeders[fid] = Feeder(feeder_data)
+    updated = {"id": fid, "name": "Renamed", "__typename": "FeederForOwner"}
+    graphql_mock.side_effect = [{"data": {"feederUpdate": updated}}]
+    result = await bbclient.set_feeder_options(fid, name="Renamed", bogus="x")
+    assert result == updated
+    variables = graphql_mock.call_args_list[0].kwargs["variables"]
+    assert variables["feederId"] == fid
+    assert variables["feederUpdateInput"] == {"name": "Renamed"}
+    assert bbclient.feeders[fid]["name"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_share_medias(bbclient: BirdBuddy, graphql_mock: AsyncMock):
+    """share_medias posts the media ids and returns the success flag."""
+    graphql_mock.side_effect = [{"data": {"mediaShareToggle": {"success": True}}}]
+    assert await bbclient.share_medias(["m1", "m2"], share=True) is True
+    variables = graphql_mock.call_args_list[0].kwargs["variables"]
+    assert variables["mediaShareToggleInput"] == {
+        "mediaIds": ["m1", "m2"],
+        "share": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_set_power_profile_refreshes_after_async_change(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, api_payloads: dict
+):
+    """set_power_profile refreshes to read the applied profile.
+
+    Verified live: the mutation returns InProgressResult with the *old*
+    profile (the change applies asynchronously), so the client refreshes and
+    reads the new value from the updated feeder.
+    """
+    feeder_data = api_payloads["me"]["feeders"][0]
+    fid = feeder_data["id"]
+    bbclient._feeders[fid] = Feeder(feeder_data)
+    in_progress = {
+        "data": {
+            "feederUpdatePowerProfile": {
+                "__typename": "FeederUpdatePowerProfileInProgressResult",
+                # Stale value: the change has not applied yet.
+                "feeder": {"powerProfile": "STANDARD_MODE"},
+            }
+        }
+    }
+    me_after = copy.deepcopy(api_payloads["me"])
+    me_after["feeders"][0]["powerProfile"] = "POWER_SAVER_MODE"
+    graphql_mock.side_effect = [in_progress, {"data": {"me": me_after}}]
+
+    result = await bbclient.set_power_profile(fid, PowerProfile.POWER_SAVE)
+    assert result == {"powerProfile": "POWER_SAVER_MODE"}
+    sent = graphql_mock.call_args_list[0].kwargs["variables"]
+    assert sent["feederUpdatePowerProfileInput"] == {"powerProfile": "POWER_SAVER_MODE"}
+
+
+@pytest.mark.asyncio
+async def test_update_firmware_check_up_to_date(
+    bbclient: BirdBuddy, graphql_mock: AsyncMock, api_payloads: dict
+):
+    """update_firmware_check parses an up-to-date firmware status.
+
+    Verified live: a feeder already on the latest firmware returns
+    SucceededResult with matching firmwareVersion/availableFirmwareVersion,
+    which is_complete, so the client refreshes its cached feeder.
+    """
+    feeder_data = api_payloads["me"]["feeders"][0]
+    fid = feeder_data["id"]
+    bbclient._feeders[fid] = Feeder(feeder_data)
+    graphql_mock.side_effect = [
+        {
+            "data": {
+                "feederFirmwareUpdateCheckProgress": {
+                    "__typename": "FeederFirmwareUpdateSucceededResult",
+                    "feeder": {
+                        "availableFirmwareVersion": "1.8.1",
+                        "firmwareVersion": "1.8.1",
+                    },
+                }
+            }
+        }
+    ]
+    status = await bbclient.update_firmware_check(fid)
+    assert status.is_complete is True
+    assert status.is_in_progress is False
+    assert status.feeder.version == "1.8.1"


### PR DESCRIPTION
A bit of additional hardening and test coverage, plus improvements to the API dumper script.

## Summary

- **Harden collection pagination** — `collection()` and `_iter_pages()` now raise `UnexpectedResponseError` on a malformed page instead of a bare `KeyError`/`TypeError`.
- **Add a sanitized real API payload fixture** — `tests/fixtures/api_payloads.json` is a scrubbed capture; adds model tests that pin the feeder, new-postcard, and postcard-analysis objects.
- **Add client tests** — cover sign-in, token refresh, refresh, collection filtering, feeder options, media sharing, power profile, and the firmware check via the graphql mock and fixture.
- **Extend the payload dumper** — capture the ME profile and collections (this is what produced the test fixture), and make `POSTCARD_COLLECT` opt-in via `BB_COLLECT_POSTCARD_ID`, so a default run is read-only (previously it collected a postcard on every run, which might negatively surprise devs).

## Notes

- Coverage rises 77% to 83% (`client.py` 58% to 70%).
- Re-ran the dumper read-only against my own BB account: the captured `me`, `collections`, `new_postcards`, and `reanalyze` shapes all match the committed fixtures, and I confirmed that no postcard was collected.